### PR TITLE
add emonpi board manifest

### DIFF
--- a/boards/emonpi.json
+++ b/boards/emonpi.json
@@ -9,7 +9,7 @@
   "frameworks": [
     "arduino"
   ],
-  "name": "BitWizard Raspduino",
+  "name": "emonpi",
   "upload": {
     "maximum_ram_size": 2048,
     "maximum_size": 32256,

--- a/boards/emonpi.json
+++ b/boards/emonpi.json
@@ -1,0 +1,22 @@
+{
+  "build": {
+    "core": "arduino",
+    "extra_flags": "-DARDUINO_ARCH_AVR -DAVR_RASPDUINO",
+    "f_cpu": "16000000L",
+    "mcu": "atmega328p",
+    "variant": "standard"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "BitWizard Raspduino",
+  "upload": {
+    "maximum_ram_size": 2048,
+    "maximum_size": 32256,
+    "protocol": "arduino",
+    "require_upload_port": true,
+    "speed": 115200
+  },
+  "url": "http://github.com/openenergymonitor/emonpi",
+  "vendor": "OpenEnergyMonitor"
+}

--- a/boards/emonpi.json
+++ b/boards/emonpi.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "core": "arduino",
-    "extra_flags": "-DARDUINO_ARCH_AVR -DAVR_RASPDUINO",
+    "extra_flags": "-DARDUINO_ARCH_AVR -DAVR_EMONPI",
     "f_cpu": "16000000L",
     "mcu": "atmega328p",
     "variant": "standard"

--- a/boards/emonpi.json
+++ b/boards/emonpi.json
@@ -9,7 +9,7 @@
   "frameworks": [
     "arduino"
   ],
-  "name": "emonpi",
+  "name": "OpenEnergyMonitor emonPi",
   "upload": {
     "maximum_ram_size": 2048,
     "maximum_size": 32256,


### PR DESCRIPTION
See forum thread: https://community.platformio.org/t/uploading-to-avr-using-raspberry-pi-gpio-avrdude-gpio-reset/360/2

emonPi board also needs GPIO reset similar to raspduino but on GPIO 4 /pin 7:

https://github.com/platformio/platformio/blob/develop/platformio/builder/scripts/atmelavr.py#L52

I will submit a separate PR to platformio repo