### PR TITLE
a more convinient way to specify uploader

### DIFF
--- a/builder/main.py
+++ b/builder/main.py
@@ -159,7 +159,7 @@ env.Append(
     )
 )
 
-if "BOARD" in env and "digispark" in env.BoardConfig().get("build.core", ""):
+if env.subst("$UPLOAD_PROTOCOL") in ("digispark", "micronucleus"):
     env.Replace(
         UPLOADER="micronucleus",
         UPLOADERFLAGS=[


### PR DESCRIPTION
The `micronuclus` bootloaer/uploader are famous for several ATtiny
MCUs, majorly targeting the ATtinyX5 and ATtinyX7.
However, current `builder/main.py` will only upload when the board
is `digispark` varients.

Here we check the `upload.protocol` variable instead of `build.core`
to determine which uploader to use, so it's a lot easier to use
this powerful tiny uploader for different cores.
