### PR TITLE
Update protrinket5ftdi.json to correct label

### DIFF
--- a/boards/protrinket5ftdi.json
+++ b/boards/protrinket5ftdi.json
@@ -9,7 +9,7 @@
   "frameworks": [
     "arduino"
   ], 
-  "name": "Adafruit Pro Trinket 5V/16MHz (USB)", 
+  "name": "Adafruit Pro Trinket 5V/16MHz (FTDI)", 
   "upload": {
     "maximum_ram_size": 2048, 
     "maximum_size": 28672, 


### PR DESCRIPTION
The current Pro Trinket 5V FTDI board file uses the same label as the USB board file. Corrected this to reflect the FTDI connection.