### PR TITLE
Avrdude flag -e to execute a required chip erase before upload.

### DIFF
--- a/boards/attiny2313.json
+++ b/boards/attiny2313.json
@@ -14,6 +14,7 @@
     "maximum_ram_size": 128,
     "maximum_size": 2048,
     "protocol": "buspirate",
+    "extra_flags": "-e",
     "require_upload_port": true
   },
   "url": "http://www.microchip.com/wwwproducts/en/ATTINY2313",

--- a/boards/attiny4313.json
+++ b/boards/attiny4313.json
@@ -14,6 +14,7 @@
     "maximum_ram_size": 256,
     "maximum_size": 4096,
     "protocol": "buspirate",
+    "extra_flags": "-e",
     "require_upload_port": true
   },
   "url": "http://www.microchip.com/wwwproducts/en/ATTINY4313",


### PR DESCRIPTION
The erase is required for ATtiny X313 chips.