### PR TITLE
Support net: upload port

### DIFF
--- a/builder/main.py
+++ b/builder/main.py
@@ -66,7 +66,7 @@ def BeforeUpload(target, source, env):  # pylint: disable=W0613,W0621
         _rpi_sysgpio("/sys/class/gpio/unexport", pin_num)
     else:
         if not upload_options.get("disable_flushing", False) \
-            and not env.get("UPLOAD_PORT").startswith("net:"):
+            and not env.get("UPLOAD_PORT", "").startswith("net:"):
             env.FlushSerialBuffer("$UPLOAD_PORT")
 
         before_ports = get_serialports()


### PR DESCRIPTION
Support net:host:port upload port as it is supported by avrdude. 
See http://www.nongnu.org/avrdude/user-manual/avrdude_4.html#Option-Descriptions "-P port" description.
See https://community.platformio.org/t/flash-via-tcp-to-uart-bridge/880/7 for the discussion