### PR TITLE
Moteinos fuses and MightyHat addtion

### DIFF
--- a/boards/mightyhat.json
+++ b/boards/mightyhat.json
@@ -1,0 +1,28 @@
+{
+  "build": {
+    "core": "arduino",
+    "extra_flags": "-DARDUINO_ARCH_AVR -DARDUINO_AVR_MOTEINO -DARDUINO_AVR_MIGHTYHAT",
+    "f_cpu": "16000000L",
+    "mcu": "atmega328p",
+    "variant": "standard"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "fuses": {
+    "efuse": "0xFD",
+    "hfuse": "0xDC",
+    "lfuse": "0xDE",
+    "lock": "0xCF"
+  },
+  "name": "LowPowerLab Moteino",
+  "upload": {
+    "maximum_ram_size": 2048,
+    "maximum_size": 31744,
+    "protocol": "arduino",
+    "require_upload_port": true,
+    "speed": 115200
+  },
+  "url": "https://lowpowerlab.com/shop/product/130",
+  "vendor": "LowPowerLab"
+}

--- a/boards/moteino.json
+++ b/boards/moteino.json
@@ -9,6 +9,12 @@
   "frameworks": [
     "arduino"
   ],
+  "fuses": {
+    "efuse": "0xFD",
+    "hfuse": "0xDC",
+    "lfuse": "0xDE",
+    "lock": "0xCF"
+  }, 
   "name": "LowPowerLab Moteino",
   "upload": {
     "maximum_ram_size": 2048,

--- a/boards/moteinomega.json
+++ b/boards/moteinomega.json
@@ -9,6 +9,12 @@
   "frameworks": [
     "arduino"
   ],
+  "fuses": {
+    "efuse": "0xFD",
+    "hfuse": "0xDE",
+    "lfuse": "0xDE",
+    "lock": "0xCF"
+  },
   "name": "LowPowerLab MoteinoMEGA",
   "upload": {
     "maximum_ram_size": 16384,


### PR DESCRIPTION
This pool request add fuses to Moteino and MoteinoMega boards from LowPowerLab.com based on configurations available at Arduino IDE. It also add a new board from same vendor called MightyHat, a hat for RPi that serves as PSU, power control for the Pi as well as RF gateway between radionetwork and Pi.