### PR TITLE
Dwenguino timeout

### DIFF
--- a/boards/dwenguino.json
+++ b/boards/dwenguino.json
@@ -1,43 +1,44 @@
 {
   "build": {
-    "core": "dwenguino", 
-    "extra_flags": "-DARDUINO_ARCH_AVR -DARDUINO_AVR_DWENGUINO", 
-    "f_cpu": "16000000L", 
+    "core": "dwenguino",
+    "extra_flags": "-DARDUINO_ARCH_AVR -DARDUINO_AVR_DWENGUINO",
+    "f_cpu": "16000000L",
     "hwids": [
       [
-        "0xd3e0", 
+        "0xd3e0",
         "0x601b"
-      ], 
+      ],
       [
-        "0xd3e0", 
+        "0xd3e0",
         "0x601a"
       ]
-    ], 
-    "mcu": "at90usb646", 
+    ],
+    "mcu": "at90usb646",
     "usb_product": "Dwenguino board",
     "variant": "dwenguino"
-  }, 
+  },
   "frameworks": [
     "arduino"
-  ], 
+  ],
   "fuses": {
-    "efuse": "0xFB", 
-    "hfuse": "0xDA", 
-    "lfuse": "0xFF", 
+    "efuse": "0xFB",
+    "hfuse": "0xDA",
+    "lfuse": "0xFF",
     "lock": "0x2F",
     "unlock": "0x3F"
-  }, 
+  },
   "name": "Dwenguino",
   "upload": {
-    "maximum_ram_size": 2048, 
-    "maximum_size": 61440, 
-    "protocol": "avr109", 
-    "require_upload_port": true, 
+    "maximum_ram_size": 2048,
+    "maximum_size": 61440,
+    "protocol": "avr109",
+    "require_upload_port": true,
     "speed": 57600,
     "wait_for_upload": true,
+    "wait_for_upload_force": true,
     "use_1200bps_touch": true,
     "disable_flushing": true
-  }, 
+  },
   "url": "http://www.dwengo.org/",
   "vendor": "Dwengo"
 }


### PR DESCRIPTION
This fixes https://github.com/platformio/platformio-core/pull/1051 in a better way, without touching the code. 

It turned out that WaitForNewSerialPort was never called in when uploading to the Dwenguino board.