### PR TITLE
Add support for Sleepy Pi board

### DIFF
--- a/boards/sleepypi.json
+++ b/boards/sleepypi.json
@@ -1,0 +1,27 @@
+{
+  "build": {
+    "core": "arduino", 
+    "extra_flags": "-DARDUINO_ARCH_AVR -DARDUINO_AVR_PRO", 
+    "f_cpu": "8000000L", 
+    "mcu": "atmega328p", 
+    "variant": "standard"
+  }, 
+  "frameworks": [
+    "arduino"
+  ], 
+  "fuses": {
+    "efuse": "0x05", 
+    "hfuse": "0xDA", 
+    "lfuse": "0xFF"
+  }, 
+  "name": "SpellFoundry Sleepy Pi 2", 
+  "upload": {
+    "maximum_ram_size": 2048, 
+    "maximum_size": 30720, 
+    "protocol": "arduino", 
+    "require_upload_port": true, 
+    "speed": 57600
+  }, 
+  "url": "https://spellfoundry.com/product/sleepy-pi-2/", 
+  "vendor": "SpellFoundry"
+}

--- a/builder/main.py
+++ b/builder/main.py
@@ -51,13 +51,19 @@ def BeforeUpload(target, source, env):  # pylint: disable=W0613,W0621
     env.AutodetectUploadPort()
     env.Append(UPLOADERFLAGS=["-P", '"$UPLOAD_PORT"'])
 
-    if env.subst("$BOARD") in ("raspduino", "emonpi"):
+    if env.subst("$BOARD") in ("raspduino", "emonpi", "sleepypi"):
 
         def _rpi_sysgpio(path, value):
             with open(path, "w") as f:
                 f.write(str(value))
 
-        pin_num = 18 if env.subst("$BOARD") == "raspduino" else 4
+        if env.subst("$BOARD") == "raspduino":
+            pin_num = 18
+        elif env.subst("$BOARD") == "sleepypi":
+            pin_num = 22
+        else:
+            pin_num = 4
+
         _rpi_sysgpio("/sys/class/gpio/export", pin_num)
         _rpi_sysgpio("/sys/class/gpio/gpio%d/direction" % pin_num, "out")
         _rpi_sysgpio("/sys/class/gpio/gpio%d/value" % pin_num, 1)


### PR DESCRIPTION
## Changes

* Add a new board for the [Sleepy Pi 2](https://spellfoundry.com/product/sleepy-pi-2/)
* Update code to use GPIO pin 22 for the serial DTR command to reset the atmega328p

I had originally created a [forum post](https://community.platformio.org/t/flashing-sleepypi-with-gpio-dtr/2919) for this, but I decided to push ahead with my own attempt.

## Extra info
* How to reset the DTR pin with a [hacked up avrdude](https://spellfoundry.com/sleepy-pi/setting-arduino-ide-raspbian/#Setting_up_the_Reset_DTR_pin)
* [Board description for the Sleepy Pi 2](https://github.com/SpellFoundry/Sleepy-Pi-Setup/blob/master/boards.txt)

## Notes

I have not tested this yet, but I'm starting the PR incase there is feedback.  I will comment again once I have tested this. **UPDATE: I tested this and it does work with a Sleepy Pi 2.**