### PR TITLE
Fix issue with failing upload for Dwenguino board.

### DIFF
--- a/boards/dwenguino.json
+++ b/boards/dwenguino.json
@@ -37,7 +37,8 @@
     "wait_for_upload": true,
     "wait_for_upload_force": true,
     "use_1200bps_touch": true,
-    "disable_flushing": true
+    "disable_flushing": true,
+    "wait_for_upload_port": true
   },
   "url": "http://www.dwengo.org/",
   "vendor": "Dwengo"


### PR DESCRIPTION
PIO should wait for the port to reappear after resetting the Dwenguino. Otherwise it can be that the board has not yet appeared while the software expects it to. This issue occurred on Linux and macOS for me. 