### PR TITLE
Add support for AT90PWM216

### DIFF
--- a/boards/at90pwm216.json
+++ b/boards/at90pwm216.json
@@ -1,0 +1,20 @@
+{
+  "build": {
+    "core": "atmelavr",
+    "extra_flags": "-D__AVR_AT90PWM216__",
+    "f_cpu": "16000000L",
+    "mcu": "at90pwm216"
+  },
+  "fuses": {
+    "lfuse": "0x62",
+    "hfuse": "0xDF",
+    "efuse": "0xF9"
+  },
+  "name": "Atmel AT90PWM216",
+  "upload": {
+    "maximum_ram_size": 1024,
+    "maximum_size": 16384
+  },
+  "url": "http://www.microchip.com/wwwproducts/en/AT90PWM216",
+  "vendor": "Microchip"
+}

--- a/boards/at90pwm316.json
+++ b/boards/at90pwm316.json
@@ -2,6 +2,7 @@
   "build": {
     "core": "atmelavr",
     "extra_flags": "-D__AVR_AT90PWM316__",
+    "f_cpu": "16000000L",
     "mcu": "at90pwm316"
   },
   "fuses": {

--- a/boards/at90pwm316.json
+++ b/boards/at90pwm316.json
@@ -6,9 +6,9 @@
     "mcu": "at90pwm316"
   },
   "fuses": {
-    "lfuse": "0x41",
+    "lfuse": "0x62",
     "hfuse": "0xDF",
-    "efuse": "0xF9",
+    "efuse": "0xF9"
   },
   "name": "Atmel AT90PWM316",
   "upload": {

--- a/boards/at90pwm316.json
+++ b/boards/at90pwm316.json
@@ -9,7 +9,6 @@
     "lfuse": "0x41",
     "hfuse": "0xDF",
     "efuse": "0xF9",
-    "lock": "0xFF"
   },
   "name": "Atmel AT90PWM316",
   "upload": {

--- a/boards/at90pwm316.json
+++ b/boards/at90pwm316.json
@@ -1,0 +1,20 @@
+{
+  "build": {
+    "core": "atmelavr",
+    "extra_flags": "-D__AVR_AT90PWM316__",
+    "mcu": "at90pwm316"
+  },
+  "fuses": {
+    "lfuse": "0x41",
+    "hfuse": "0xDF",
+    "efuse": "0xF9",
+    "lock": "0xFF"
+  },
+  "name": "Atmel AT90PWM316",
+  "upload": {
+    "maximum_ram_size": 1024,
+    "maximum_size": 16384
+  },
+  "url": "http://www.microchip.com/wwwproducts/en/AT90PWM316",
+  "vendor": "Microchip"
+}


### PR DESCRIPTION
Native AVR only, no framework support.
Including updates to AT90PWM316.
All tested.

PR #80 