### PR TITLE
Add board definition for 8MHz Moteino

### DIFF
--- a/boards/moteino8mhz.json
+++ b/boards/moteino8mhz.json
@@ -1,0 +1,28 @@
+{
+  "build": {
+    "core": "arduino",
+    "extra_flags": "-DARDUINO_AVR_MOTEINO",
+    "f_cpu": "8000000L",
+    "mcu": "atmega328p",
+    "variant": "standard"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "fuses": {
+    "efuse": "0xFE",
+    "hfuse": "0xDC",
+    "lfuse": "0xD2",
+    "lock": "0xCF"
+  },
+  "name": "LowPowerLab Moteino (8 Mhz)",
+  "upload": {
+    "maximum_ram_size": 2048,
+    "maximum_size": 31744,
+    "protocol": "arduino",
+    "require_upload_port": true,
+    "speed": 57600
+  },
+  "url": "https://lowpowerlab.com/shop/product/159",
+  "vendor": "LowPowerLab"
+}


### PR DESCRIPTION
Adds board definitions for the [8MHz variant of Moteino](https://lowpowerlab.com/shop/product/159) from LowPowerLab.com based on their oficial configurations available for the Arduino IDE.