### PR TITLE
Correct MightyCore ATmega8535 mcu value

### DIFF
--- a/boards/mightycore8535.json
+++ b/boards/mightycore8535.json
@@ -3,7 +3,7 @@
     "core": "MightyCore",
     "extra_flags": "-DARDUINO_AVR_ATmega8535",
     "f_cpu": "16000000L",
-    "mcu": "atmega16",
+    "mcu": "atmega8535",
     "variant": "mightycore"
   },
   "frameworks": [


### PR DESCRIPTION
mcu was incorrectly set to atmega16 for the MightyCore ATmega8535.