### PR TITLE
feat(py3): use modernize to support Python3

### DIFF
--- a/builder/frameworks/arduino.py
+++ b/builder/frameworks/arduino.py
@@ -22,6 +22,7 @@ kinds of creative coding, interactive objects, spaces or physical experiences.
 http://arduino.cc/en/Reference/HomePage
 """
 
+from __future__ import absolute_import
 from os.path import isdir, join
 
 from SCons.Script import DefaultEnvironment

--- a/builder/frameworks/simba.py
+++ b/builder/frameworks/simba.py
@@ -21,6 +21,7 @@ http://simba-os.readthedocs.org
 
 """
 
+from __future__ import absolute_import
 from os.path import join, sep
 
 from SCons.Script import DefaultEnvironment, SConscript

--- a/builder/main.py
+++ b/builder/main.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
+from __future__ import print_function
 from os.path import join
 from time import sleep
 
@@ -27,7 +29,7 @@ def BeforeUpload(target, source, env):  # pylint: disable=W0613,W0621
         return
 
     if "micronucleus" in env['UPLOADER']:
-        print "Please unplug/plug device ..."
+        print("Please unplug/plug device ...")
 
     upload_options = {}
     if "BOARD" in env:

--- a/platform.py
+++ b/platform.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from platformio.managers.platform import PlatformBase
 
 


### PR DESCRIPTION
The [`python-modernize`][1] can help with this considerably, e.g.:

    python-modernize . -w

will automatically use the [`six`][2] module to apply numerous
transformations required for Python 2/3 compatability.  The
[`python-modernize`][1] tool was used to generate all changes in this
commit.

[1]: https://github.com/python-modernize/python-modernize
[2]: https://pythonhosted.org/six/