### PR TITLE
patch arduino.py so git commit framework versions work during builds

### DIFF
--- a/builder/frameworks/arduino.py
+++ b/builder/frameworks/arduino.py
@@ -33,6 +33,12 @@ FRAMEWORK_DIR = platform.get_package_dir("framework-arduinoavr")
 FRAMEWORK_VERSION = platform.get_package_version("framework-arduinoavr")
 assert isdir(FRAMEWORK_DIR)
 
+# hack the version when it has no dots and is probably a commit id
+# not great to hard code the arduino version but there is no where
+# else to put it
+if "." not in FRAMEWORK_VERSION:
+    FRAMEWORK_VERSION = "~1.10620."+FRAMEWORK_VERSION
+
 # USB flags
 ARDUINO_USBDEFINES = [
     "ARDUINO_ARCH_AVR",


### PR DESCRIPTION
Using a git URL as a version for framework-arduinoavr generates an error because arduino.py expects to be able to parse the arduino version from it and in the case of a git URL its passed a commit id.