### PR TITLE
Add ATmega48PB/88PB/168PB

### DIFF
--- a/boards/ATMEGA168PB.json
+++ b/boards/ATMEGA168PB.json
@@ -1,0 +1,22 @@
+{
+  "build": {
+    "core": "MiniCore",
+    "extra_flags": "-DARDUINO_AVR_ATmega168PB",
+    "f_cpu": "16000000L",
+    "mcu": "atmega168pb",
+    "variant": "minicore_pb-variant"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "ATMEGA168PB",
+  "upload": {
+    "maximum_ram_size": 1024,
+    "maximum_size": 15872,
+    "protocol": "arduino",
+    "require_upload_port": true,
+    "speed": 115200
+  },
+  "url": "https://www.microchip.com/wwwproducts/en/ATmega168PB",
+  "vendor": "Microchip"
+}

--- a/boards/ATMEGA48PB.json
+++ b/boards/ATMEGA48PB.json
@@ -1,0 +1,21 @@
+{
+  "build": {
+    "core": "MiniCore",
+    "extra_flags": "-DARDUINO_AVR_ATmega48PB",
+    "f_cpu": "16000000L",
+    "mcu": "atmega48pb",
+    "variant": "minicore_pb-variant"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "ATMEGA48PB",
+  "upload": {
+    "maximum_ram_size": 512,
+    "maximum_size": 4096,
+    "protocol": "arduino",
+    "require_upload_port": false
+  },
+  "url": "https://www.microchip.com/wwwproducts/en/ATmega48PB",
+  "vendor": "Microchip"
+}

--- a/boards/ATMEGA88PB.json
+++ b/boards/ATMEGA88PB.json
@@ -1,0 +1,22 @@
+{
+  "build": {
+    "core": "MiniCore",
+    "extra_flags": "-DARDUINO_AVR_ATmega88PB",
+    "f_cpu": "16000000L",
+    "mcu": "atmega88pb",
+    "variant": "minicore_pb-variant"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "ATMEGA88PB",
+  "upload": {
+    "maximum_ram_size": 1024,
+    "maximum_size": 7680,
+    "protocol": "arduino",
+    "require_upload_port": true,
+    "speed": 115200
+  },
+  "url": "https://www.microchip.com/wwwproducts/en/ATmega88PB",
+  "vendor": "Microchip"
+}


### PR DESCRIPTION
I totally forgot to add these last time. These are rarely used, but it's still nice to have proper support for them. No changes to the corefiles.