### PR TITLE
Add Chip45's Crumb128 V5.0 AVR ATmega Module

### DIFF
--- a/boards/chip45_crumb128v50.json
+++ b/boards/chip45_crumb128v50.json
@@ -1,0 +1,22 @@
+{
+    "build": {
+        "core": "MegaCore",
+        "f_cpu": "16000000L",
+        "mcu": "atmega128"
+    },
+    "name": "Crumb128 V5.0 AVR ATmega Module",
+    "upload": {
+        "maximum_ram_size": 4096,
+        "maximum_size": 131072,
+        "protocol": "usbasp",
+        "port": "usb",
+        "speed": 115200
+    },
+    "fuses": {
+        "efuse": "0xFF",
+        "hfuse": "0xC8",
+        "lfuse": "0xDF"
+    },
+    "url": "https://www.chip45.com/products/crumb128-5.0_avr_atmega_module_board_atmega128_usb_rs232.php",
+    "vendor": "Chip45"
+}


### PR DESCRIPTION
I'm working with a Crumb128.
Loving PlatformIO but doesn't have the Chip45 boards we are using.

I'm only pushing the "Crumb128 V5.0 AVR" since it's the only i could test. But the naming convention of `chip45_crumb128v50` will allow to add [all of them](https://www.chip45.com/categories/sam_smart_arm_atmega_xmega_avr_microcontroller_modules_boards.php) in the future. 

Hope it get's merged so I don't have to pass this json up everytime ^_^