### PR TITLE
Add FYSETC F6 V1.4

### DIFF
--- a/boards/fysetc_f6_14.json
+++ b/boards/fysetc_f6_14.json
@@ -1,0 +1,28 @@
+{
+  "build": {
+    "core": "arduino",
+    "extra_flags": "-DARDUINO_AVR_MEGA2560",
+    "f_cpu": "16000000L",
+    "hwids": [
+      [
+        "0x27b2",
+        "0x0002"
+      ]
+    ],
+    "mcu": "atmega2560",
+    "variant": "fysetcf6"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "FYSETC F6",
+  "upload": {
+    "maximum_ram_size": 8192,
+    "maximum_size": 258048,
+    "protocol": "wiring",
+    "require_upload_port": true,
+    "speed": 115200
+  },
+  "url": "https://www.fysetc.com/",
+  "vendor": "FYSETC"
+}


### PR DESCRIPTION
Add to support FYSETC F6 V1.4 . I already Open a PR to update variant 
https://github.com/platformio/platformio-pkg-framework-arduinoavr/tree/master/variants/fysetcf6
But the platformio-pkg-framework-arduinoavr is read only state , i can't see the progress of the PR.
And if you can's see the PR , the variants file is located here
https://github.com/GerogeFu/platformio-pkg-framework-arduinoavr/tree/update-fysetc-f6/variants/fysetcf6