### PR TITLE
Use tinyX7_New variant

### DIFF
--- a/boards/attiny167.json
+++ b/boards/attiny167.json
@@ -4,7 +4,7 @@
     "extra_flags": "-DARDUINO_AVR_ATTINYX7",
     "f_cpu": "8000000L",
     "mcu": "attiny167",
-    "variant": "tinyX7"
+    "variant": "tinyX7_New"
   },
   "frameworks": [
     "arduino"

--- a/boards/attiny87.json
+++ b/boards/attiny87.json
@@ -4,7 +4,7 @@
     "extra_flags": "-DARDUINO_AVR_ATTINYX7",
     "f_cpu": "8000000L",
     "mcu": "attiny87",
-    "variant": "tinyX7"
+    "variant": "tinyX7_New"
   },
   "frameworks": [
     "arduino"


### PR DESCRIPTION
ATTiny core default is to use the tinyX7_New, leaving tinyX7 as a compatibility option for old code. 

https://github.com/SpenceKonde/ATTinyCore/blob/master/avr/boards.txt#L749

Edit: Meant to also mention that the PR re-aligns the pin assignment with the documentation at https://github.com/SpenceKonde/ATTinyCore/blob/master/avr/extras/ATtiny_x7.md, and is raised as a consequense of this forum thread. https://community.platformio.org/t/arduino-as-isp-upload-to-attiny167/12852/13