### PR TITLE
Fixed attiny4313 board definition.

### DIFF
--- a/boards/attiny4313.json
+++ b/boards/attiny4313.json
@@ -2,7 +2,7 @@
   "build": {
     "core": "tiny",
     "extra_flags": "-DARDUINO_AVR_ATTINYX313",
-    "f_cpu": "800000L",
+    "f_cpu": "8000000L",
     "mcu": "attiny4313",
     "variant": "tinyX313"
   },

--- a/boards/attiny4313.json
+++ b/boards/attiny4313.json
@@ -1,8 +1,8 @@
 {
   "build": {
-    "core": "tinymodern",
+    "core": "tiny",
     "extra_flags": "-DARDUINO_AVR_ATTINYX313",
-    "f_cpu": "8000000L",
+    "f_cpu": "800000L",
     "mcu": "attiny4313",
     "variant": "tinyX313"
   },


### PR DESCRIPTION
Use tiny instead of tinycore and fixed the f_cpu flag

When using `tinymodern` we get the following error:
```
Building in release mode
Compiling .pio\build\attiny4313\src\main.cpp.o
Compiling .pio\build\attiny4313\FrameworkArduino\HardwareSerial.cpp.o
Compiling .pio\build\attiny4313\FrameworkArduino\Print.cpp.o
Compiling .pio\build\attiny4313\FrameworkArduino\Stream.cpp.o
Compiling .pio\build\attiny4313\FrameworkArduino\Tone.cpp.o
Compiling .pio\build\attiny4313\FrameworkArduino\WInterrupts.c.o
Compiling .pio\build\attiny4313\FrameworkArduino\WMath.cpp.o
Compiling .pio\build\attiny4313\FrameworkArduino\WString.cpp.o
Compiling .pio\build\attiny4313\FrameworkArduino\abi.cpp.o
Compiling .pio\build\attiny4313\FrameworkArduino\main.cpp.o
Compiling .pio\build\attiny4313\FrameworkArduino\new.cpp.o
Compiling .pio\build\attiny4313\FrameworkArduino\wiring.c.o
Compiling .pio\build\attiny4313\FrameworkArduino\wiring_analog.c.o
Compiling .pio\build\attiny4313\FrameworkArduino\wiring_digital.c.o
Compiling .pio\build\attiny4313\FrameworkArduino\wiring_pulse.c.o
Compiling .pio\build\attiny4313\FrameworkArduino\wiring_shift.c.o
C:\Users\Sven\.platformio\packages\framework-arduino-avr-attiny\cores\tinymodern\Tone.cpp:45:2: error: #error Only five or fifteen prescalers are supported. Update the code to support the number of actual prescalers.
 #error Only five or fifteen prescalers are supported.  Update the code to support the number of actual prescalers.
  ^
C:\Users\Sven\.platformio\packages\framework-arduino-avr-attiny\cores\tinymodern\Tone.cpp:56:59: error: 'TONETIMER_MAXIMUM_DIVISOR' was not declared in this scope
 const unsigned int Tone_Lowest_Frequency = (F_CPU + (2L * TONETIMER_MAXIMUM_DIVISOR - 1L)) / (2L * TONETIMER_MAXIMUM_DIVISOR);
                                                           ^
C:\Users\Sven\.platformio\packages\framework-arduino-avr-attiny\cores\tinymodern\Tone.cpp:56:100: error: 'TONETIMER_MAXIMUM_DIVISOR' was not declared in this scope
<snip>
```
All the compile errors go away when using the `tiny` core.


The f_cpu flag also appears to be wrong. The attiny4313 has an internal oscillator that runs at +-8Mhz. When using an exteral clock it can run up to 20Mhz. See the datascheet: <https://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-2586-AVR-8-bit-Microcontroller-ATtiny25-ATtiny45-ATtiny85_Datasheet.pdf>