### PR TITLE
Update and improve fuse calculation script

### DIFF
--- a/builder/fuses.py
+++ b/builder/fuses.py
@@ -116,16 +116,19 @@ def get_hfuse(target, uart, oscillator, bod, eesave, jtagen):
             return 0xdf & ~ jtagen_offset & ~ eesave_offset
         else:
             return 0xde & ~ jtagen_offset & ~ eesave_offset
+
     elif target in targets_2:
         if uart == "no_bootloader":
             return 0xdf & ~ eesave_offset
         else:
             return 0xde & ~ eesave_offset
+
     elif target in targets_3:
         if uart == "no_bootloader":
             return 0xdd & ~ jtagen_offset & ~ eesave_offset
         else:
             return 0xdc & ~ jtagen_offset & ~ eesave_offset
+
     elif target in targets_4:
         if bod == "4.3v":
             return 0xdc & ~ eesave_offset
@@ -135,16 +138,19 @@ def get_hfuse(target, uart, oscillator, bod, eesave, jtagen):
             return 0xde & ~ eesave_offset
         else:
             return 0xdf & ~ eesave_offset
+
     elif target in targets_5:
         if uart == "no_bootloader":
             return 0xdf & ~ jtagen_offset & ~ ckopt_offset & ~ eesave_offset
         else:
             return 0xde & ~ jtagen_offset & ~ ckopt_offset & ~ eesave_offset
+
     elif target in targets_6:
         if uart == "no_bootloader":
             return 0xdd & ~ ckopt_offset & ~ eesave_offset
         else:
             return 0xdc & ~ ckopt_offset & ~ eesave_offset
+
     elif target in targets_7:
         if bod == "4.3v":
             return 0x9
@@ -160,28 +166,28 @@ def get_hfuse(target, uart, oscillator, bod, eesave, jtagen):
         env.Exit(1)
 
 
-def get_efuse(mcu, uart, bod):
+def get_efuse(target, uart, bod):
 
-    mcus_1 = (
+    targets_1 = (
         "atmega2561", "atmega2560", "atmega1284", "atmega1284p",
         "atmega1281", "atmega1280", "atmega644a", "atmega644p",
         "atmega640", "atmega328", "atmega328p", "atmega324a",
         "atmega324p", "atmega324pa", "atmega164a", "atmega164p")
-    mcus_2 = ("atmega328pb", "atmega324pb")
-    mcus_3 = (
+    targets_2 = ("atmega328pb", "atmega324pb")
+    targets_3 = (
         "atmega168", "atmega168p", "atmega168pb", "atmega88",
         "atmega88p", "atmega88pb")
-    mcus_4 = ("atmega128", "atmega64", "atmega48", "atmega48p")
-    mcus_5 = ("at90can128", "at90can64", "at90can32")
-    mcus_6 = ("atmega162",)
+    targets_4 = ("atmega128", "atmega64", "atmega48", "atmega48p")
+    targets_5 = ("at90can128", "at90can64", "at90can32")
+    targets_6 = ("atmega162",)
 
-    mcu_without_efuse = ("atmega8535", "atmega8515", "atmega8", "atmega16",
+    targets_without_efuse = ("atmega8535", "atmega8515", "atmega8", "atmega16",
         "atmega32", "attiny13a", "attiny13")
 
-    if mcu in mcu_without_efuse:
+    if target in targets_without_efuse:
         return None
 
-    if mcu in mcus_1:
+    if target in targets_1:
         if bod == "4.3v":
             return 0xfc
         elif bod == "2.7v":
@@ -191,7 +197,7 @@ def get_efuse(mcu, uart, bod):
         else:
             return 0xff
 
-    elif mcu in mcus_2:
+    elif target in targets_2:
         if bod == "4.3v":
             return 0xf4
         elif bod == "2.7v":
@@ -201,13 +207,13 @@ def get_efuse(mcu, uart, bod):
         else:
             return 0xf7
 
-    elif mcu in mcus_3:
+    elif target in targets_3:
         return 0xfd if uart == "no_bootloader" else 0xfc
 
-    elif mcu in mcus_4:
+    elif target in targets_4:
         return 0xff
 
-    elif mcu in mcus_5:
+    elif target in targets_5:
         if bod == "4.1v":
             return 0xfd
         elif bod == "4.0v":
@@ -225,7 +231,7 @@ def get_efuse(mcu, uart, bod):
         else:
             return 0xff
 
-    elif mcu in mcus_6:
+    elif target in targets_6:
         if bod == "4.3v":
             return 0xf9
         elif bod == "2.7v":
@@ -236,7 +242,7 @@ def get_efuse(mcu, uart, bod):
             return 0xff
 
     else:
-        sys.stderr.write("Error: Couldn't calculate efuse for %s\n" % mcu)
+        sys.stderr.write("Error: Couldn't calculate efuse for %s\n" % target)
         env.Exit(1)
 
 

--- a/builder/fuses.py
+++ b/builder/fuses.py
@@ -296,18 +296,34 @@ if core in ("MiniCore", "MegaCore", "MightyCore", "MajorCore", "MicroCore"):
     ckout = board.get("hardware.ckout", "no").lower()
     cfd = board.get("hardware.cfd", "no").lower()
 
-    print("\nTARGET CONFIGURATION:\n"
-          "---------------------")
-    print("Target = %s\n"
-          "Clock speed = %s\n"
-          "Oscillator = %s\n"
-          "BOD level = %s\n"
-          "UART port = %s\n"
-          "Save EEPROM = %s\n"
-          "Clock output = %s\n"
-          "JTAG enable = %s\n"
-          "Clock failure detection = %s\n"
-          % (target, f_cpu, oscillator, bod, uart, eesave, ckout, jtagen, cfd))
+    print("\nTARGET CONFIGURATION:")
+    print("---------------------")
+    print("Target = %s" % target)
+    print("Clock speed = %s" % f_cpu)
+    print("Oscillator = %s" % oscillator)
+    print("BOD level = %s" % bod)
+    print("Save EEPROM = %s" % eesave)
+
+    if target not in ("attiny13", "attiny13a"):
+        print("UART port = %s" % uart)
+
+    if target not in (
+        "atmega8535", "atmega8515", "atmega128", "atmega64", "atmega32",
+        "atmega16", "atmega8", "attiny13", "attiny13a"):
+        print("Clock output = %s" % ckout)
+
+    if target in (
+        "atmega2561", "atmega2560", "atmega1284", "atmega1284p", "atmega1281",
+        "atmega1280", "atmega644a", "atmega644p", "atmega640", "atmega324a",
+        "atmega324p", "atmega324pa", "atmega324pb", "at90can128", "at90can64",
+        "at90can32", "atmega164a", "atmega164p", "atmega162", "atmega128",
+        "atmega64", "atmega32"):
+        print("JTAG enable = %s" % jtagen)
+
+    if target in ("atmega324pb", "atmega328pb"):
+        print("CFD enable = %s" % cfd)
+
+    print("---------------------")
 
     lfuse = lfuse or hex(get_lfuse(target, f_cpu, oscillator, bod, eesave, ckout))
     hfuse = hfuse or hex(get_hfuse(target, uart, oscillator, bod, eesave, jtagen))
@@ -332,7 +348,7 @@ if efuse:
     efuse = efuse if isinstance(efuse, str) else hex(efuse)
     fuses_cmd.append("-Uefuse:w:%s:m" % efuse)
 
-print("Selected fuses: [lfuse = %s, hfuse = %s%s]" % (
+print("\nSelected fuses: [lfuse = %s, hfuse = %s%s]" % (
     lfuse, hfuse, ", efuse = %s" % efuse if efuse else ""))
 
 fuses_action = env.VerboseAction(" ".join(fuses_cmd), "Setting fuses")

--- a/builder/fuses.py
+++ b/builder/fuses.py
@@ -27,6 +27,8 @@ def get_lfuse(target, f_cpu, oscillator, bod, eesave, ckout):
     if target in targets_1:
         if oscillator == "external":
             return 0xf7 & ~ ckout_offset
+        elif oscillator == "external_clock":
+            return 0xe0 & ~ ckout_offset
         else:
             if f_cpu == "8000000L":
                 return 0xe2 & ~ ckout_offset
@@ -36,6 +38,8 @@ def get_lfuse(target, f_cpu, oscillator, bod, eesave, ckout):
     elif target in targets_2:
         if oscillator == "external":
             return 0xff & ~ ckout_offset
+        elif oscillator == "external_clock":
+            return 0xe0 & ~ ckout_offset
         else:
             if f_cpu == "8000000L":
                 return 0xe2 & ~ ckout_offset
@@ -53,6 +57,8 @@ def get_lfuse(target, f_cpu, oscillator, bod, eesave, ckout):
         bod_offset = bod_bits << 6
         if oscillator == "external":
             return 0xff & ~ bod_offset
+        elif oscillator == "external_clock":
+            return 0xe0 & ~ bod_offset
         else:
             if f_cpu == "8000000L":
                 return 0xe4 & ~ bod_offset
@@ -62,7 +68,7 @@ def get_lfuse(target, f_cpu, oscillator, bod, eesave, ckout):
     elif target in targets_4:
         eesave_bit = 1 if eesave == "yes" else 0
         eesave_offset = eesave_bit << 6
-        if oscillator == "external":
+        if oscillator == "external" or oscillator == "external_clock":
             return 0x78 & ~ eesave_offset
         else:
             if f_cpu == "9600000L":
@@ -249,8 +255,8 @@ def is_target_without_bootloader(target):
 def get_lock_bits(target):
     if is_target_without_bootloader(target):
         return "0xff"
-
-    return "0x0f"
+    else:
+        return "0x0f"
 
 
 board = env.BoardConfig()


### PR DESCRIPTION
Fix an issue where the lfuse couldn't be calculated for ATmega64 and ATmega128.
Make use of the JTAGEN fuse, so that JTAG can be enabled on targets that supports it.
Make use of the CKOUT fuse, so the internal clock can be outputted on devices that supports it.