### PR TITLE
Do not include occupied bootloader space in maximum_size

### DIFF
--- a/boards/AT90CAN128.json
+++ b/boards/AT90CAN128.json
@@ -15,7 +15,7 @@
   "name": "AT90CAN128",
   "upload": {
     "maximum_ram_size": 4096,
-    "maximum_size": 130048,
+    "maximum_size": 131072,
     "protocol": "arduino",
     "require_upload_port": true,
     "speed": 115200

--- a/boards/AT90CAN32.json
+++ b/boards/AT90CAN32.json
@@ -15,7 +15,7 @@
   "name": "AT90CAN32",
   "upload": {
     "maximum_ram_size": 2048,
-    "maximum_size": 31744,
+    "maximum_size": 32768,
     "protocol": "arduino",
     "require_upload_port": true,
     "speed": 115200

--- a/boards/AT90CAN64.json
+++ b/boards/AT90CAN64.json
@@ -15,7 +15,7 @@
   "name": "AT90CAN64",
   "upload": {
     "maximum_ram_size": 4096,
-    "maximum_size": 64512,
+    "maximum_size": 65536,
     "protocol": "arduino",
     "require_upload_port": true,
     "speed": 115200

--- a/boards/ATmega128.json
+++ b/boards/ATmega128.json
@@ -18,7 +18,7 @@
   "name": "ATmega128/A",
   "upload": {
     "maximum_ram_size": 4096,
-    "maximum_size": 130048,
+    "maximum_size": 131072,
     "protocol": "arduino",
     "require_upload_port": true,
     "speed": 115200

--- a/boards/ATmega1280.json
+++ b/boards/ATmega1280.json
@@ -21,7 +21,7 @@
   "name": "ATmega1280",
   "upload": {
     "maximum_ram_size": 8192,
-    "maximum_size": 130048,
+    "maximum_size": 131072,
     "protocol": "arduino",
     "require_upload_port": true,
     "speed": 115200

--- a/boards/ATmega1281.json
+++ b/boards/ATmega1281.json
@@ -18,7 +18,7 @@
   "name": "ATmega1281",
   "upload": {
     "maximum_ram_size": 8192,
-    "maximum_size": 130048,
+    "maximum_size": 131072,
     "protocol": "arduino",
     "require_upload_port": true,
     "speed": 115200

--- a/boards/ATmega1284.json
+++ b/boards/ATmega1284.json
@@ -18,7 +18,7 @@
   "name": "ATmega1284",
   "upload": {
     "maximum_ram_size": 16384,
-    "maximum_size": 130048,
+    "maximum_size": 131072,
     "protocol": "arduino",
     "require_upload_port": true,
     "speed": 115200

--- a/boards/ATmega1284P.json
+++ b/boards/ATmega1284P.json
@@ -18,7 +18,7 @@
   "name": "ATmega1284P",
   "upload": {
     "maximum_ram_size": 16384,
-    "maximum_size": 130048,
+    "maximum_size": 131072,
     "protocol": "arduino",
     "require_upload_port": true,
     "speed": 115200

--- a/boards/ATmega16.json
+++ b/boards/ATmega16.json
@@ -18,7 +18,7 @@
   "name": "ATmega16",
   "upload": {
     "maximum_ram_size": 1024,
-    "maximum_size": 15872,
+    "maximum_size": 16384,
     "protocol": "arduino",
     "require_upload_port": true,
     "speed": 115200

--- a/boards/ATmega162.json
+++ b/boards/ATmega162.json
@@ -15,7 +15,7 @@
   "name": "ATmega162",
   "upload": {
     "maximum_ram_size": 1024,
-    "maximum_size": 15872,
+    "maximum_size": 16384,
     "protocol": "arduino",
     "require_upload_port": true,
     "speed": 115200

--- a/boards/ATmega164A.json
+++ b/boards/ATmega164A.json
@@ -15,7 +15,7 @@
   "name": "ATmega164A",
   "upload": {
     "maximum_ram_size": 1024,
-    "maximum_size": 15872,
+    "maximum_size": 16384,
     "protocol": "arduino",
     "require_upload_port": true,
     "speed": 115200

--- a/boards/ATmega164P.json
+++ b/boards/ATmega164P.json
@@ -18,7 +18,7 @@
   "name": "ATmega164P/PA",
   "upload": {
     "maximum_ram_size": 1024,
-    "maximum_size": 15872,
+    "maximum_size": 16384,
     "protocol": "arduino",
     "require_upload_port": true,
     "speed": 115200

--- a/boards/ATmega168.json
+++ b/boards/ATmega168.json
@@ -18,7 +18,7 @@
   "name": "ATmega168/A",
   "upload": {
     "maximum_ram_size": 1024,
-    "maximum_size": 15872,
+    "maximum_size": 16384,
     "protocol": "arduino",
     "require_upload_port": true,
     "speed": 115200

--- a/boards/ATmega168P.json
+++ b/boards/ATmega168P.json
@@ -18,7 +18,7 @@
   "name": "ATmega168P/PA",
   "upload": {
     "maximum_ram_size": 1024,
-    "maximum_size": 15872,
+    "maximum_size": 16384,
     "protocol": "arduino",
     "require_upload_port": true,
     "speed": 115200

--- a/boards/ATmega168PB.json
+++ b/boards/ATmega168PB.json
@@ -15,7 +15,7 @@
   "name": "ATmega168PB",
   "upload": {
     "maximum_ram_size": 1024,
-    "maximum_size": 15872,
+    "maximum_size": 16384,
     "protocol": "arduino",
     "require_upload_port": true,
     "speed": 115200

--- a/boards/ATmega2560.json
+++ b/boards/ATmega2560.json
@@ -21,7 +21,7 @@
   "name": "ATmega2560",
   "upload": {
     "maximum_ram_size": 8192,
-    "maximum_size": 261120,
+    "maximum_size": 262144,
     "protocol": "arduino",
     "require_upload_port": true,
     "speed": 115200

--- a/boards/ATmega2561.json
+++ b/boards/ATmega2561.json
@@ -15,7 +15,7 @@
   "name": "ATmega2561",
   "upload": {
     "maximum_ram_size": 8192,
-    "maximum_size": 261120,
+    "maximum_size": 262144,
     "protocol": "arduino",
     "require_upload_port": true,
     "speed": 115200

--- a/boards/ATmega32.json
+++ b/boards/ATmega32.json
@@ -15,7 +15,7 @@
   "name": "ATmega32",
   "upload": {
     "maximum_ram_size": 2048,
-    "maximum_size": 32256,
+    "maximum_size": 32768,
     "protocol": "arduino",
     "require_upload_port": true,
     "speed": 115200

--- a/boards/ATmega324A.json
+++ b/boards/ATmega324A.json
@@ -18,7 +18,7 @@
   "name": "ATmega324A",
   "upload": {
     "maximum_ram_size": 2048,
-    "maximum_size": 32256,
+    "maximum_size": 32768,
     "protocol": "arduino",
     "require_upload_port": true,
     "speed": 115200

--- a/boards/ATmega324P.json
+++ b/boards/ATmega324P.json
@@ -18,7 +18,7 @@
   "name": "ATmega324P",
   "upload": {
     "maximum_ram_size": 2048,
-    "maximum_size": 32256,
+    "maximum_size": 32768,
     "protocol": "arduino",
     "require_upload_port": true,
     "speed": 115200

--- a/boards/ATmega324PA.json
+++ b/boards/ATmega324PA.json
@@ -18,7 +18,7 @@
   "name": "ATmega324PA",
   "upload": {
     "maximum_ram_size": 2048,
-    "maximum_size": 32256,
+    "maximum_size": 32768,
     "protocol": "arduino",
     "require_upload_port": true,
     "speed": 115200

--- a/boards/ATmega324PB.json
+++ b/boards/ATmega324PB.json
@@ -15,7 +15,7 @@
   "name": "ATmega324PB",
   "upload": {
     "maximum_ram_size": 2048,
-    "maximum_size": 32256,
+    "maximum_size": 32768,
     "protocol": "arduino",
     "require_upload_port": true,
     "speed": 115200

--- a/boards/ATmega328.json
+++ b/boards/ATmega328.json
@@ -21,7 +21,7 @@
   "name": "ATmega328",
   "upload": {
     "maximum_ram_size": 2048,
-    "maximum_size": 32256,
+    "maximum_size": 32768,
     "protocol": "arduino",
     "require_upload_port": true,
     "speed": 115200

--- a/boards/ATmega328P.json
+++ b/boards/ATmega328P.json
@@ -21,7 +21,7 @@
   "name": "ATmega328P/PA",
   "upload": {
     "maximum_ram_size": 2048,
-    "maximum_size": 32256,
+    "maximum_size": 32768,
     "protocol": "arduino",
     "require_upload_port": true,
     "speed": 115200

--- a/boards/ATmega328PB.json
+++ b/boards/ATmega328PB.json
@@ -15,7 +15,7 @@
   "name": "ATmega328PB",
   "upload": {
     "maximum_ram_size": 2048,
-    "maximum_size": 32256,
+    "maximum_size": 32768,
     "protocol": "arduino",
     "require_upload_port": true,
     "speed": 115200

--- a/boards/ATmega64.json
+++ b/boards/ATmega64.json
@@ -15,7 +15,7 @@
   "name": "ATmega64/A",
   "upload": {
     "maximum_ram_size": 4096,
-    "maximum_size": 64512,
+    "maximum_size": 65536,
     "protocol": "arduino",
     "require_upload_port": true,
     "speed": 115200

--- a/boards/ATmega640.json
+++ b/boards/ATmega640.json
@@ -15,7 +15,7 @@
   "name": "ATmega640",
   "upload": {
     "maximum_ram_size": 8192,
-    "maximum_size": 64512,
+    "maximum_size": 65536,
     "protocol": "arduino",
     "require_upload_port": true,
     "speed": 115200

--- a/boards/ATmega644A.json
+++ b/boards/ATmega644A.json
@@ -15,7 +15,7 @@
   "name": "ATmega644/A",
   "upload": {
     "maximum_ram_size": 4096,
-    "maximum_size": 64512,
+    "maximum_size": 65536,
     "protocol": "arduino",
     "require_upload_port": true,
     "speed": 115200

--- a/boards/ATmega644P.json
+++ b/boards/ATmega644P.json
@@ -18,7 +18,7 @@
   "name": "ATmega644P/PA",
   "upload": {
     "maximum_ram_size": 4096,
-    "maximum_size": 64512,
+    "maximum_size": 65536,
     "protocol": "arduino",
     "require_upload_port": true,
     "speed": 115200

--- a/boards/ATmega8.json
+++ b/boards/ATmega8.json
@@ -18,7 +18,7 @@
   "name": "ATmega8/A",
   "upload": {
     "maximum_ram_size": 1024,
-    "maximum_size": 7680,
+    "maximum_size": 8192,
     "protocol": "arduino",
     "require_upload_port": true,
     "speed": 115200

--- a/boards/ATmega8515.json
+++ b/boards/ATmega8515.json
@@ -15,7 +15,7 @@
   "name": "ATmega8515",
   "upload": {
     "maximum_ram_size": 512,
-    "maximum_size": 7680,
+    "maximum_size": 8192,
     "protocol": "arduino",
     "require_upload_port": true,
     "speed": 115200

--- a/boards/ATmega8535.json
+++ b/boards/ATmega8535.json
@@ -15,7 +15,7 @@
   "name": "ATmega8535",
   "upload": {
     "maximum_ram_size": 512,
-    "maximum_size": 7680,
+    "maximum_size": 8192,
     "protocol": "arduino",
     "require_upload_port": true,
     "speed": 115200

--- a/boards/ATmega88.json
+++ b/boards/ATmega88.json
@@ -18,7 +18,7 @@
   "name": "ATmega88/A",
   "upload": {
     "maximum_ram_size": 1024,
-    "maximum_size": 7680,
+    "maximum_size": 8192,
     "protocol": "arduino",
     "require_upload_port": true,
     "speed": 115200

--- a/boards/ATmega88P.json
+++ b/boards/ATmega88P.json
@@ -18,7 +18,7 @@
   "name": "ATmega88P/PA",
   "upload": {
     "maximum_ram_size": 1024,
-    "maximum_size": 7680,
+    "maximum_size": 8192,
     "protocol": "arduino",
     "require_upload_port": true,
     "speed": 115200

--- a/boards/ATmega88PB.json
+++ b/boards/ATmega88PB.json
@@ -15,7 +15,7 @@
   "name": "ATmega88PB",
   "upload": {
     "maximum_ram_size": 1024,
-    "maximum_size": 7680,
+    "maximum_size": 8192,
     "protocol": "arduino",
     "require_upload_port": true,
     "speed": 115200


### PR DESCRIPTION
The default maximum_size field should instead reflect the total amount of flash memory the microcontroller has regardless if the user has loaded a bootloader or not. #207 related.

The actual bootloader size (512 or 1024 bytes depending on target) should instead be subtracted from `maximum_size` if `board_hardware.uart != no_bootloader`