### PR TITLE
fix avrdude WARNING for deprecated setting of lock/unlock fuse.

### DIFF
--- a/builder/bootloader.py
+++ b/builder/bootloader.py
@@ -78,8 +78,8 @@ if not isfile(bootloader_path):
 
 fuses_action = env.SConscript("fuses.py", exports="env")
 
-lock_bits = board.get("bootloader.lock_bits", "0x0F")
-unlock_bits = board.get("bootloader.unlock_bits", "0x3F")
+lock_bits = board.get("bootloader.lock_bits", "0xCF")
+unlock_bits = board.get("bootloader.unlock_bits", "0xEF")
 
 env.Replace(
     BOOTUPLOADER="avrdude",


### PR DESCRIPTION
issue #237.
Method: following chip datasheets, set unused 2 most significant bits to 1.
Tested OK with PIO core 5.1.0, home 3.3.3, framework-arduino-avr 5.0.0, tool-avrdude 6.3.0, toolchain-atmelavr 5.4.0