### PR TITLE
Fixed the avrdude upload process

### DIFF
--- a/builder/main.py
+++ b/builder/main.py
@@ -52,7 +52,7 @@ def BeforeUpload(target, source, env):  # pylint: disable=W0613,W0621
         return
 
     env.AutodetectUploadPort()
-    env.Append(UPLOADERFLAGS=["-P", '"$UPLOAD_PORT"'])
+    env.Append(UPLOADERFLAGS=["-P", '$UPLOAD_PORT'])
 
     if env.subst("$BOARD") in ("raspduino", "emonpi", "sleepypi"):
 

--- a/builder/main.py
+++ b/builder/main.py
@@ -52,7 +52,7 @@ def BeforeUpload(target, source, env):  # pylint: disable=W0613,W0621
         return
 
     env.AutodetectUploadPort()
-    env.Append(UPLOADERFLAGS=["-P", '$UPLOAD_PORT'])
+    env.Append(UPLOADERFLAGS=["-P", "$UPLOAD_PORT"])
 
     if env.subst("$BOARD") in ("raspduino", "emonpi", "sleepypi"):
 


### PR DESCRIPTION
Scons 4.1.0 escapes the values of construction variable lists before adding them to the command line in the execute function as it can be seen here https://scons.org/doc/4.1.0/HTML/scons-api/_modules/SCons/Action/#CommandAction.execute .
This leads to the avrdude not being able to open the serial port on windows as the quotes get escaped and passed to the avrdude. So I've removed the quotes that were getting passed to the `Append` functions as it already escapes the serial port argument's value. I can confirm that this problem exists on platform-atmelavr 3.2.0 on Windows 10 20H2.