### PR TITLE
Remove attiny85 CLOCK_SOURCE from extra_flags

### DIFF
--- a/boards/attiny85.json
+++ b/boards/attiny85.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "core": "tiny",
-    "extra_flags": "-DARDUINO_AVR_ATTINYX5 -DNEOPIXELPORT=PORTB -DCLOCK_SOURCE=6",
+    "extra_flags": "-DARDUINO_AVR_ATTINYX5 -DNEOPIXELPORT=PORTB",
     "f_cpu": "8000000L",
     "mcu": "attiny85",
     "variant": "tinyX5"


### PR DESCRIPTION
As detailed in #264 by @Granjow, I can also confirm that the clock frequency settings in 3.4.0 are behaving unexpectedly now with ATtiny85's. I've tested this PR against an oscillator tuning project that was broken in this release, and it appears to fix the issue.