### PR TITLE
Support auto port detection for custom protocol

### DIFF
--- a/builder/main.py
+++ b/builder/main.py
@@ -198,7 +198,10 @@ if upload_protocol == "micronucleus":
     upload_actions = [env.VerboseAction("$UPLOADCMD", "Uploading $SOURCE")]
 
 elif upload_protocol == "custom":
-    upload_actions = [env.VerboseAction("$UPLOADCMD", "Uploading $SOURCE")]
+    upload_actions = [
+        env.VerboseAction(BeforeUpload, "Looking for upload port..."),
+        env.VerboseAction("$UPLOADCMD", "Uploading $SOURCE"),
+    ]
 
 else:
     env.Replace(


### PR DESCRIPTION
I need to specify upload_port when I use Arduino as ISP to upload firmware but I want platform to auto detect the port.
How about to call BeforeUpload for custom upload protocol?

References:
https://docs.platformio.org/en/stable/projectconf/section_env_upload.html
https://docs.platformio.org/en/latest/platforms/atmelavr.html#upload-using-programmer