### PR TITLE
Add support for ATmegaxx5/xx50 and ATmegaxx9/xx90 chip families

### DIFF
--- a/boards/ATmega165.json
+++ b/boards/ATmega165.json
@@ -3,7 +3,7 @@
     "core": "MegaCore",
     "extra_flags": "-DARDUINO_AVR_ATmega165",
     "f_cpu": "16000000L",
-    "mcu": "atmega165",
+    "mcu": "atmega165a",
     "variant": "64-pin-avr"
   },
   "bootloader":{

--- a/boards/ATmega165.json
+++ b/boards/ATmega165.json
@@ -1,0 +1,25 @@
+{
+  "build": {
+    "core": "MegaCore",
+    "extra_flags": "-DARDUINO_AVR_ATmega165",
+    "f_cpu": "16000000L",
+    "mcu": "atmega165",
+    "variant": "64-pin-avr"
+  },
+  "bootloader":{
+    "led_pin": "B5"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "ATmega165/A",
+  "upload": {
+    "maximum_ram_size": 1024,
+    "maximum_size": 16384,
+    "protocol": "arduino",
+    "require_upload_port": true,
+    "speed": 115200
+  },
+  "url": "https://www.microchip.com/wwwproducts/en/ATmega165A",
+  "vendor": "Microchip"
+}

--- a/boards/ATmega165P.json
+++ b/boards/ATmega165P.json
@@ -1,0 +1,25 @@
+{
+  "build": {
+    "core": "MegaCore",
+    "extra_flags": "-DARDUINO_AVR_ATmega165P",
+    "f_cpu": "16000000L",
+    "mcu": "atmega165p",
+    "variant": "64-pin-avr"
+  },
+  "bootloader":{
+    "led_pin": "B5"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "ATmega165P/PA",
+  "upload": {
+    "maximum_ram_size": 1024,
+    "maximum_size": 16384,
+    "protocol": "arduino",
+    "require_upload_port": true,
+    "speed": 115200
+  },
+  "url": "https://www.microchip.com/wwwproducts/en/ATmega165P",
+  "vendor": "Microchip"
+}

--- a/boards/ATmega169.json
+++ b/boards/ATmega169.json
@@ -1,0 +1,25 @@
+{
+  "build": {
+    "core": "MegaCore",
+    "extra_flags": "-DARDUINO_AVR_ATmega169",
+    "f_cpu": "16000000L",
+    "mcu": "atmega169",
+    "variant": "64-pin-avr"
+  },
+  "bootloader":{
+    "led_pin": "B5"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "ATmega169/A",
+  "upload": {
+    "maximum_ram_size": 1024,
+    "maximum_size": 16384,
+    "protocol": "arduino",
+    "require_upload_port": true,
+    "speed": 115200
+  },
+  "url": "https://www.microchip.com/wwwproducts/en/ATmega169A",
+  "vendor": "Microchip"
+}

--- a/boards/ATmega169A.json
+++ b/boards/ATmega169A.json
@@ -1,9 +1,9 @@
 {
   "build": {
     "core": "MegaCore",
-    "extra_flags": "-DARDUINO_AVR_ATmega169",
+    "extra_flags": "-DARDUINO_AVR_ATmega169A",
     "f_cpu": "16000000L",
-    "mcu": "atmega169",
+    "mcu": "atmega169a",
     "variant": "64-pin-avr"
   },
   "bootloader":{
@@ -12,7 +12,7 @@
   "frameworks": [
     "arduino"
   ],
-  "name": "ATmega169/A",
+  "name": "ATmega169A",
   "upload": {
     "maximum_ram_size": 1024,
     "maximum_size": 16384,

--- a/boards/ATmega169P.json
+++ b/boards/ATmega169P.json
@@ -1,0 +1,25 @@
+{
+  "build": {
+    "core": "MegaCore",
+    "extra_flags": "-DARDUINO_AVR_ATmega169P",
+    "f_cpu": "16000000L",
+    "mcu": "atmega169p",
+    "variant": "64-pin-avr"
+  },
+  "bootloader":{
+    "led_pin": "B5"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "ATmega169P/PA",
+  "upload": {
+    "maximum_ram_size": 1024,
+    "maximum_size": 16384,
+    "protocol": "arduino",
+    "require_upload_port": true,
+    "speed": 115200
+  },
+  "url": "https://www.microchip.com/wwwproducts/en/ATmega169P",
+  "vendor": "Microchip"
+}

--- a/boards/ATmega169P.json
+++ b/boards/ATmega169P.json
@@ -12,7 +12,7 @@
   "frameworks": [
     "arduino"
   ],
-  "name": "ATmega169P/PA",
+  "name": "ATmega169/P/PA",
   "upload": {
     "maximum_ram_size": 1024,
     "maximum_size": 16384,

--- a/boards/ATmega325.json
+++ b/boards/ATmega325.json
@@ -1,0 +1,25 @@
+{
+  "build": {
+    "core": "MegaCore",
+    "extra_flags": "-DARDUINO_AVR_ATmega325",
+    "f_cpu": "16000000L",
+    "mcu": "atmega325",
+    "variant": "64-pin-avr"
+  },
+  "bootloader":{
+    "led_pin": "B5"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "ATmega325/A",
+  "upload": {
+    "maximum_ram_size": 2048,
+    "maximum_size": 32768,
+    "protocol": "arduino",
+    "require_upload_port": true,
+    "speed": 115200
+  },
+  "url": "https://www.microchip.com/wwwproducts/en/ATmega325",
+  "vendor": "Microchip"
+}

--- a/boards/ATmega3250.json
+++ b/boards/ATmega3250.json
@@ -1,0 +1,25 @@
+{
+  "build": {
+    "core": "MegaCore",
+    "extra_flags": "-DARDUINO_AVR_ATmega3250",
+    "f_cpu": "16000000L",
+    "mcu": "atmega3250",
+    "variant": "100-pin-avr"
+  },
+  "bootloader":{
+    "led_pin": "B7"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "ATmega3250/A",
+  "upload": {
+    "maximum_ram_size": 2048,
+    "maximum_size": 32768,
+    "protocol": "arduino",
+    "require_upload_port": true,
+    "speed": 115200
+  },
+  "url": "https://www.microchip.com/wwwproducts/en/ATmega3250",
+  "vendor": "Microchip"
+}

--- a/boards/ATmega3250P.json
+++ b/boards/ATmega3250P.json
@@ -1,0 +1,25 @@
+{
+  "build": {
+    "core": "MegaCore",
+    "extra_flags": "-DARDUINO_AVR_ATmega3250P",
+    "f_cpu": "16000000L",
+    "mcu": "atmega3250p",
+    "variant": "100-pin-avr"
+  },
+  "bootloader":{
+    "led_pin": "B7"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "ATmega3250P/PA",
+  "upload": {
+    "maximum_ram_size": 2048,
+    "maximum_size": 32768,
+    "protocol": "arduino",
+    "require_upload_port": true,
+    "speed": 115200
+  },
+  "url": "https://www.microchip.com/wwwproducts/en/ATmega3250P",
+  "vendor": "Microchip"
+}

--- a/boards/ATmega325P.json
+++ b/boards/ATmega325P.json
@@ -1,0 +1,25 @@
+{
+  "build": {
+    "core": "MegaCore",
+    "extra_flags": "-DARDUINO_AVR_ATmega325P",
+    "f_cpu": "16000000L",
+    "mcu": "atmega325p",
+    "variant": "64-pin-avr"
+  },
+  "bootloader":{
+    "led_pin": "B5"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "ATmega325P/PA",
+  "upload": {
+    "maximum_ram_size": 2048,
+    "maximum_size": 32768,
+    "protocol": "arduino",
+    "require_upload_port": true,
+    "speed": 115200
+  },
+  "url": "https://www.microchip.com/wwwproducts/en/ATmega325P",
+  "vendor": "Microchip"
+}

--- a/boards/ATmega329.json
+++ b/boards/ATmega329.json
@@ -1,0 +1,25 @@
+{
+  "build": {
+    "core": "MegaCore",
+    "extra_flags": "-DARDUINO_AVR_ATmega329",
+    "f_cpu": "16000000L",
+    "mcu": "atmega329",
+    "variant": "64-pin-avr"
+  },
+  "bootloader":{
+    "led_pin": "B5"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "ATmega329/A",
+  "upload": {
+    "maximum_ram_size": 2048,
+    "maximum_size": 32768,
+    "protocol": "arduino",
+    "require_upload_port": true,
+    "speed": 115200
+  },
+  "url": "https://www.microchip.com/wwwproducts/en/ATmega329",
+  "vendor": "Microchip"
+}

--- a/boards/ATmega3290.json
+++ b/boards/ATmega3290.json
@@ -1,0 +1,25 @@
+{
+  "build": {
+    "core": "MegaCore",
+    "extra_flags": "-DARDUINO_AVR_ATmega3290",
+    "f_cpu": "16000000L",
+    "mcu": "atmega3290",
+    "variant": "100-pin-avr"
+  },
+  "bootloader":{
+    "led_pin": "B7"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "ATmega3290/A",
+  "upload": {
+    "maximum_ram_size": 2048,
+    "maximum_size": 32768,
+    "protocol": "arduino",
+    "require_upload_port": true,
+    "speed": 115200
+  },
+  "url": "https://www.microchip.com/wwwproducts/en/ATmega3290",
+  "vendor": "Microchip"
+}

--- a/boards/ATmega3290P.json
+++ b/boards/ATmega3290P.json
@@ -1,0 +1,25 @@
+{
+  "build": {
+    "core": "MegaCore",
+    "extra_flags": "-DARDUINO_AVR_ATmega3290P",
+    "f_cpu": "16000000L",
+    "mcu": "atmega3290p",
+    "variant": "100-pin-avr"
+  },
+  "bootloader":{
+    "led_pin": "B7"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "ATmega3290P/PA",
+  "upload": {
+    "maximum_ram_size": 2048,
+    "maximum_size": 32768,
+    "protocol": "arduino",
+    "require_upload_port": true,
+    "speed": 115200
+  },
+  "url": "https://www.microchip.com/wwwproducts/en/ATmega3290P",
+  "vendor": "Microchip"
+}

--- a/boards/ATmega329P.json
+++ b/boards/ATmega329P.json
@@ -1,0 +1,25 @@
+{
+  "build": {
+    "core": "MegaCore",
+    "extra_flags": "-DARDUINO_AVR_ATmega329P",
+    "f_cpu": "16000000L",
+    "mcu": "atmega329p",
+    "variant": "64-pin-avr"
+  },
+  "bootloader":{
+    "led_pin": "B5"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "ATmega329P/PA",
+  "upload": {
+    "maximum_ram_size": 2048,
+    "maximum_size": 32768,
+    "protocol": "arduino",
+    "require_upload_port": true,
+    "speed": 115200
+  },
+  "url": "https://www.microchip.com/wwwproducts/en/ATmega329P",
+  "vendor": "Microchip"
+}

--- a/boards/ATmega645.json
+++ b/boards/ATmega645.json
@@ -1,0 +1,25 @@
+{
+  "build": {
+    "core": "MegaCore",
+    "extra_flags": "-DARDUINO_AVR_ATmega645",
+    "f_cpu": "16000000L",
+    "mcu": "atmega645",
+    "variant": "64-pin-avr"
+  },
+  "bootloader":{
+    "led_pin": "B5"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "ATmega645/A",
+  "upload": {
+    "maximum_ram_size": 4096,
+    "maximum_size": 65536,
+    "protocol": "arduino",
+    "require_upload_port": true,
+    "speed": 115200
+  },
+  "url": "https://www.microchip.com/wwwproducts/en/ATmega645",
+  "vendor": "Microchip"
+}

--- a/boards/ATmega6450.json
+++ b/boards/ATmega6450.json
@@ -1,0 +1,25 @@
+{
+  "build": {
+    "core": "MegaCore",
+    "extra_flags": "-DARDUINO_AVR_ATmega6450",
+    "f_cpu": "16000000L",
+    "mcu": "atmega6450",
+    "variant": "100-pin-avr"
+  },
+  "bootloader":{
+    "led_pin": "B7"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "ATmega6450/A",
+  "upload": {
+    "maximum_ram_size": 4096,
+    "maximum_size": 65536,
+    "protocol": "arduino",
+    "require_upload_port": true,
+    "speed": 115200
+  },
+  "url": "https://www.microchip.com/wwwproducts/en/ATmega6450",
+  "vendor": "Microchip"
+}

--- a/boards/ATmega6450P.json
+++ b/boards/ATmega6450P.json
@@ -1,0 +1,25 @@
+{
+  "build": {
+    "core": "MegaCore",
+    "extra_flags": "-DARDUINO_AVR_ATmega6450P",
+    "f_cpu": "16000000L",
+    "mcu": "atmega6450p",
+    "variant": "100-pin-avr"
+  },
+  "bootloader":{
+    "led_pin": "B7"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "ATmega6450P",
+  "upload": {
+    "maximum_ram_size": 4096,
+    "maximum_size": 65536,
+    "protocol": "arduino",
+    "require_upload_port": true,
+    "speed": 115200
+  },
+  "url": "https://www.microchip.com/wwwproducts/en/ATmega6450P",
+  "vendor": "Microchip"
+}

--- a/boards/ATmega645P.json
+++ b/boards/ATmega645P.json
@@ -1,0 +1,25 @@
+{
+  "build": {
+    "core": "MegaCore",
+    "extra_flags": "-DARDUINO_AVR_ATmega645P",
+    "f_cpu": "16000000L",
+    "mcu": "atmega645p",
+    "variant": "64-pin-avr"
+  },
+  "bootloader":{
+    "led_pin": "B5"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "ATmega645P",
+  "upload": {
+    "maximum_ram_size": 4096,
+    "maximum_size": 65536,
+    "protocol": "arduino",
+    "require_upload_port": true,
+    "speed": 115200
+  },
+  "url": "https://www.microchip.com/wwwproducts/en/ATmega645P",
+  "vendor": "Microchip"
+}

--- a/boards/ATmega649.json
+++ b/boards/ATmega649.json
@@ -1,0 +1,25 @@
+{
+  "build": {
+    "core": "MegaCore",
+    "extra_flags": "-DARDUINO_AVR_ATmega649",
+    "f_cpu": "16000000L",
+    "mcu": "atmega649",
+    "variant": "64-pin-avr"
+  },
+  "bootloader":{
+    "led_pin": "B5"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "ATmega649/A",
+  "upload": {
+    "maximum_ram_size": 4096,
+    "maximum_size": 65536,
+    "protocol": "arduino",
+    "require_upload_port": true,
+    "speed": 115200
+  },
+  "url": "https://www.microchip.com/wwwproducts/en/ATmega649",
+  "vendor": "Microchip"
+}

--- a/boards/ATmega6490.json
+++ b/boards/ATmega6490.json
@@ -1,0 +1,25 @@
+{
+  "build": {
+    "core": "MegaCore",
+    "extra_flags": "-DARDUINO_AVR_ATmega6490",
+    "f_cpu": "16000000L",
+    "mcu": "atmega6490",
+    "variant": "100-pin-avr"
+  },
+  "bootloader":{
+    "led_pin": "B7"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "ATmega6490/A",
+  "upload": {
+    "maximum_ram_size": 4096,
+    "maximum_size": 65536,
+    "protocol": "arduino",
+    "require_upload_port": true,
+    "speed": 115200
+  },
+  "url": "https://www.microchip.com/wwwproducts/en/ATmega6490",
+  "vendor": "Microchip"
+}

--- a/boards/ATmega6490P.json
+++ b/boards/ATmega6490P.json
@@ -1,0 +1,25 @@
+{
+  "build": {
+    "core": "MegaCore",
+    "extra_flags": "-DARDUINO_AVR_ATmega6490P",
+    "f_cpu": "16000000L",
+    "mcu": "atmega6490p",
+    "variant": "100-pin-avr"
+  },
+  "bootloader":{
+    "led_pin": "B7"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "ATmega6490P",
+  "upload": {
+    "maximum_ram_size": 4096,
+    "maximum_size": 65536,
+    "protocol": "arduino",
+    "require_upload_port": true,
+    "speed": 115200
+  },
+  "url": "https://www.microchip.com/wwwproducts/en/ATmega6490P",
+  "vendor": "Microchip"
+}

--- a/boards/ATmega649P.json
+++ b/boards/ATmega649P.json
@@ -1,0 +1,25 @@
+{
+  "build": {
+    "core": "MegaCore",
+    "extra_flags": "-DARDUINO_AVR_ATmega649P",
+    "f_cpu": "16000000L",
+    "mcu": "atmega649p",
+    "variant": "64-pin-avr"
+  },
+  "bootloader":{
+    "led_pin": "B5"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "ATmega649P",
+  "upload": {
+    "maximum_ram_size": 4096,
+    "maximum_size": 65536,
+    "protocol": "arduino",
+    "require_upload_port": true,
+    "speed": 115200
+  },
+  "url": "https://www.microchip.com/wwwproducts/en/ATmega649P",
+  "vendor": "Microchip"
+}

--- a/builder/fuses.py
+++ b/builder/fuses.py
@@ -32,7 +32,23 @@ def get_lfuse(target, f_cpu, oscillator, bod, eesave, ckout):
         "atmega48p",
     )
     targets_2 = (
+        "atmega6490p",
+        "atmega6490",
+        "atmega6450p",
+        "atmega6450",
+        "atmega3290p",
+        "atmega3290",
+        "atmega3250p",
+        "atmega3250",
+        "atmega649p",
+        "atmega649",
+        "atmega645p",
+        "atmega645",
+        "atmega329p",
+        "atmega329",
         "atmega328pb",
+        "atmega325p",
+        "atmega325",
         "atmega324pb",
         "atmega168pb",
         "atmega162",
@@ -123,15 +139,31 @@ def get_lfuse(target, f_cpu, oscillator, bod, eesave, ckout):
 
 def get_hfuse(target, uart, oscillator, bod, eesave, jtagen):
     targets_1 = (
+        "atmega6490p",
+        "atmega6490",
+        "atmega6450p",
+        "atmega6450",
+        "atmega3290p",
+        "atmega3290",
+        "atmega3250p",
+        "atmega3250",
         "atmega2561",
         "atmega2560",
         "atmega1284",
         "atmega1284p",
         "atmega1281",
         "atmega1280",
+        "atmega649p",
+        "atmega649",
+        "atmega645p",
+        "atmega645",
         "atmega644a",
         "atmega644p",
         "atmega640",
+        "atmega329p",
+        "atmega329",
+        "atmega325p",
+        "atmega325",
         "atmega324a",
         "atmega324p",
         "atmega324pa",
@@ -141,7 +173,15 @@ def get_hfuse(target, uart, oscillator, bod, eesave, jtagen):
         "at90can32",
     )
     targets_2 = ("atmega328", "atmega328p", "atmega328pb")
-    targets_3 = ("atmega164a", "atmega164p", "atmega162")
+    targets_3 = (
+        "atmega169p",
+        "atmega169",
+        "atmega165p",
+        "atmega165",
+        "atmega164p",
+        "atmega164a",
+        "atmega162",
+    )
     targets_4 = (
         "atmega168",
         "atmega168p",
@@ -259,7 +299,25 @@ def get_efuse(target, uart, bod, cfd):
     )
     targets_4 = ("atmega128", "atmega64", "atmega48", "atmega48p")
     targets_5 = ("at90can128", "at90can64", "at90can32")
-    targets_6 = ("atmega162",)
+    targets_6 = (
+        "atmega6490p",
+        "atmega6490",
+        "atmega6450p",
+        "atmega6450",
+        "atmega3290p",
+        "atmega3290",
+        "atmega3250p",
+        "atmega3250",
+        "atmega649p",
+        "atmega649",
+        "atmega645p",
+        "atmega645",
+        "atmega329p",
+        "atmega329",
+        "atmega325p",
+        "atmega325",
+        "atmega162",
+    )
 
     cfd_bit = 1 if cfd == "yes" else 0
     cfd_offset = cfd_bit << 3

--- a/builder/fuses.py
+++ b/builder/fuses.py
@@ -175,8 +175,10 @@ def get_hfuse(target, uart, oscillator, bod, eesave, jtagen):
     targets_2 = ("atmega328", "atmega328p", "atmega328pb")
     targets_3 = (
         "atmega169p",
+        "atmega169a",
         "atmega169",
         "atmega165p",
+        "atmega165a",
         "atmega165",
         "atmega164p",
         "atmega164a",


### PR DESCRIPTION
The latest version of MegaCore, v2.2.0 adds support for the ATmega165, ATmega169, ATmega325, ATmega329, ATmega645, ATmega649, ATmega3250, ATmega3290, ATmega6450 and ATmega6490.

This PR adds manifest files for all these. The chips also have full bootloader support through MegaCore through the existing bootloader.py script.