### PR TITLE
Add Urboot bootloader support for MicroCore

### DIFF
--- a/builder/bootloader.py
+++ b/builder/bootloader.py
@@ -57,23 +57,21 @@ def get_suitable_optiboot_binary(framework_dir, board_config):
 
 def get_suitable_urboot_binary(framework_dir, board_config):
     mcu = board_config.get("build.mcu", "").lower()
+    f_cpu = re.sub("[^0-9]", "", board_config.get("build.f_cpu", "16000000L"))
+    oscillator = board.get("hardware.oscillator", "external").lower()
     bootloader_led = board_config.get("bootloader.led_pin", "no-led").lower()
     bootloader_speed = board_config.get("bootloader.speed", env.subst("$UPLOAD_SPEED"))
     bootloader_file = "urboot_%s.hex" % mcu
 
     if core == "MicroCore":
-        f_cpu = re.sub("[^0-9]", "", board_config.get("build.f_cpu", "9600000L"))
         f_cpu_error = board_config.get("hardware.f_cpu_error", "0.0")
         uart = board_config.get("hardware.uart", "swio_rxb1_txb0").lower()
-        oscillator = board.get("hardware.oscillator", "internal").lower()
         if oscillator == "internal":
             clock_speed = int(f_cpu) + int((float(f_cpu_error)/100)*int(f_cpu))
         else:
             clock_speed = int(f_cpu)
     else:
-        f_cpu = re.sub("[^0-9]", "", board_config.get("build.f_cpu", "16000000L"))
         uart = board_config.get("hardware.uart", "uart0").lower()
-        oscillator = board.get("hardware.oscillator", "external").lower()
         clock_speed = int(f_cpu)
 
     bootloader_path = join(

--- a/builder/bootloader.py
+++ b/builder/bootloader.py
@@ -57,17 +57,25 @@ def get_suitable_optiboot_binary(framework_dir, board_config):
 
 def get_suitable_urboot_binary(framework_dir, board_config):
     mcu = board_config.get("build.mcu", "").lower()
-    f_cpu = re.sub("[^0-9]", "", board_config.get("build.f_cpu", "16000000L"))
-    f_cpu_error = board_config.get("hardware.f_cpu_error", "0.0")
-    oscillator = board.get("hardware.oscillator", "external").lower()
-    uart = board_config.get("hardware.uart", "swio_rxb1_txb0" if core == "MicroCore" else "uart0").lower()
-    bootloader_speed = board_config.get("bootloader.speed", env.subst("$UPLOAD_SPEED"))
     bootloader_led = board_config.get("bootloader.led_pin", "no-led").lower()
+    bootloader_speed = board_config.get("bootloader.speed", env.subst("$UPLOAD_SPEED"))
     bootloader_file = "urboot_%s.hex" % mcu
-    if oscillator == "internal":
-        clock_speed = int(f_cpu) + int((float(f_cpu_error)/100)*int(f_cpu))
+
+    if core == "MicroCore":
+        f_cpu = re.sub("[^0-9]", "", board_config.get("build.f_cpu", "9600000L"))
+        f_cpu_error = board_config.get("hardware.f_cpu_error", "0.0")
+        uart = board_config.get("hardware.uart", "swio_rxb1_txb0").lower()
+        oscillator = board.get("hardware.oscillator", "internal").lower()
+        if oscillator == "internal":
+            clock_speed = int(f_cpu) + int((float(f_cpu_error)/100)*int(f_cpu))
+        else:
+            clock_speed = int(f_cpu)
     else:
+        f_cpu = re.sub("[^0-9]", "", board_config.get("build.f_cpu", "16000000L"))
+        uart = board_config.get("hardware.uart", "uart0").lower()
+        oscillator = board.get("hardware.oscillator", "external").lower()
         clock_speed = int(f_cpu)
+
     bootloader_path = join(
         framework_dir,
         "bootloaders",

--- a/builder/bootloader.py
+++ b/builder/bootloader.py
@@ -106,7 +106,6 @@ elif core == "MicroCore":
 else:
     if not isfile(bootloader_path):
         bootloader_path = join(framework_dir, "bootloaders", bootloader_path)
-        print(bootloader_path)
 
     if not board.get("bootloader", {}):
         sys.stderr.write("Error: missing bootloader configuration!\n")
@@ -115,6 +114,8 @@ else:
 if not isfile(bootloader_path):
     sys.stderr.write("Error: Couldn't find bootloader image %s\n" % bootloader_path)
     env.Exit(1)
+
+print("Using bootloader image:\n%s" % bootloader_path)
 
 fuses_action = env.SConscript("fuses.py", exports="env")
 

--- a/builder/bootloader.py
+++ b/builder/bootloader.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import sys
-import re
 from os.path import isfile, join
 
 from SCons.Script import Import, Return
@@ -57,22 +56,22 @@ def get_suitable_optiboot_binary(framework_dir, board_config):
 
 def get_suitable_urboot_binary(framework_dir, board_config):
     mcu = board_config.get("build.mcu", "").lower()
-    f_cpu = re.sub("[^0-9]", "", board_config.get("build.f_cpu", "16000000L"))
+    f_cpu = int(board_config.get("build.f_cpu", "16000000L").strip("UL"))
     oscillator = board.get("hardware.oscillator", "external").lower()
     bootloader_led = board_config.get("bootloader.led_pin", "no-led").lower()
     bootloader_speed = board_config.get("bootloader.speed", env.subst("$UPLOAD_SPEED"))
     bootloader_file = "urboot_%s.hex" % mcu
 
     if core == "MicroCore":
-        f_cpu_error = board_config.get("hardware.f_cpu_error", "0.0")
+        f_cpu_error = float(board_config.get("hardware.f_cpu_error", "0.0"))
         uart = board_config.get("hardware.uart", "swio_rxb1_txb0").lower()
         if oscillator == "internal":
-            clock_speed = int(f_cpu) + int((float(f_cpu_error)/100)*int(f_cpu))
+            clock_speed = f_cpu + int(f_cpu_error/100 * f_cpu)
         else:
-            clock_speed = int(f_cpu)
+            clock_speed = f_cpu
     else:
         uart = board_config.get("hardware.uart", "uart0").lower()
-        clock_speed = int(f_cpu)
+        clock_speed = f_cpu
 
     bootloader_path = join(
         framework_dir,

--- a/builder/bootloader.py
+++ b/builder/bootloader.py
@@ -120,8 +120,12 @@ if not isfile(bootloader_path):
 
 fuses_action = env.SConscript("fuses.py", exports="env")
 
-lock_bits = board.get("bootloader.lock_bits", "0xFF" if core == "MicroCore" else "0x0F")
-unlock_bits = board.get("bootloader.unlock_bits", "0xFF" if core == "MicroCore" else "0x3F")
+if core == "MicroCore":
+    lock_bits = board.get("bootloader.lock_bits", "0xFF")
+    unlock_bits = board.get("bootloader.unlock_bits", "0xFF")
+else:
+    lock_bits = board.get("bootloader.lock_bits", "0x0F")
+    unlock_bits = board.get("bootloader.unlock_bits", "0x3F")
 
 env.Replace(
     BOOTUPLOADER="avrdude",


### PR DESCRIPTION
The latest version of MicroCore supports the new [Urboot bootloader](https://github.com/stefanrueger/urboot).
This PR allows setting fuses and burning the correct bootloader using PlatformIO.

The internal 9.6 and 4.8 MHz oscillator in the ATtiny13/A is notorious for being inaccurate. So much so that using a UART bootloader might become difficult. That's why MicroCore provides [various bootloader binaries](https://github.com/MCUdude/MicroCore/tree/master/avr/bootloaders/urboot) the bootloader script can choose from in order to use one that matches the user specification.

Specify the desired `f_cpu` and `f_cpu_error`, and the correct binary will be flashed.
There are a few rules though.
* There only exist pre-compiled bootloader files for the following internal oscillator options:
  - 9.6 MHz
  - 4.8 MHz
  - 1.2 MHz
  - 600 kHz
  - 128 kHz
* For each base frequency, the user can specify an error between -10 and 10 percent, in 1.25% steps.
* `f_cpu_error` is only useful when the internal oscillator option is selected

I'd like to hear what @valeros thinks about this. I'll update the official PlatformIO docs and the MicroCore docs to reflect the changes when/if this gets merged.

Note that I will also migrate over to Urboot for my other Arduino cores as well, but this may take some time and is not covered in this PR.