### PR TITLE
excessive quotes fix

### DIFF
--- a/builder/bootloader.py
+++ b/builder/bootloader.py
@@ -131,10 +131,9 @@ env.Replace(
         "-p",
         "$BOARD_MCU",
         "-C",
-        # '"%s"' % # quotation marks already added automatically because BOOTUPLOADERFLAGS is a list
         join(env.PioPlatform().get_package_dir("tool-avrdude") or "", "avrdude.conf"),
     ],
-    BOOTFLAGS='-Uflash:w:"%s":i' % bootloader_path  +" "+  "-Ulock:w:%s:m" % lock_bits, # can't be list, because of doubled quotes around bootloader_path
+    BOOTFLAGS=['-Uflash:w:"%s":i' % bootloader_path, "-Ulock:w:%s:m" % lock_bits],
     UPLOADBOOTCMD="$BOOTUPLOADER $BOOTUPLOADERFLAGS $UPLOAD_FLAGS $BOOTFLAGS",
 )
 
@@ -149,7 +148,7 @@ else:
     )
 
 bootloader_actions = [
-    fuses_action,
+    # fuses_action,
     env.VerboseAction("$UPLOADBOOTCMD", "Uploading bootloader"),
 ]
 

--- a/builder/bootloader.py
+++ b/builder/bootloader.py
@@ -148,7 +148,7 @@ else:
     )
 
 bootloader_actions = [
-    # fuses_action,
+    fuses_action,
     env.VerboseAction("$UPLOADBOOTCMD", "Uploading bootloader"),
 ]
 

--- a/builder/bootloader.py
+++ b/builder/bootloader.py
@@ -131,10 +131,10 @@ env.Replace(
         "-p",
         "$BOARD_MCU",
         "-C",
-        '"%s"'
-        % join(env.PioPlatform().get_package_dir("tool-avrdude") or "", "avrdude.conf"),
+        # '"%s"' % # quotation marks already added automatically because BOOTUPLOADERFLAGS is a list
+        join(env.PioPlatform().get_package_dir("tool-avrdude") or "", "avrdude.conf"),
     ],
-    BOOTFLAGS=['-Uflash:w:"%s":i' % bootloader_path, "-Ulock:w:%s:m" % lock_bits],
+    BOOTFLAGS='-Uflash:w:"%s":i' % bootloader_path  +" "+  "-Ulock:w:%s:m" % lock_bits, # can't be list, because of doubled quotes around bootloader_path
     UPLOADBOOTCMD="$BOOTUPLOADER $BOOTUPLOADERFLAGS $UPLOAD_FLAGS $BOOTFLAGS",
 )
 

--- a/builder/fuses.py
+++ b/builder/fuses.py
@@ -533,8 +533,8 @@ env.Replace(
         "-p",
         "$BOARD_MCU",
         "-C",
-        '"%s"'
-        % join(env.PioPlatform().get_package_dir("tool-avrdude") or "", "avrdude.conf"),
+        # '"%s"' % # quotation marks already added automatically because FUSESUPLOADERFLAGS is a list
+        join(env.PioPlatform().get_package_dir("tool-avrdude") or "", "avrdude.conf"),
     ],
     FUSESFLAGS=[
         "-Ulock:w:%s:m" % lock,

--- a/builder/fuses.py
+++ b/builder/fuses.py
@@ -533,7 +533,6 @@ env.Replace(
         "-p",
         "$BOARD_MCU",
         "-C",
-        # '"%s"' % # quotation marks already added automatically because FUSESUPLOADERFLAGS is a list
         join(env.PioPlatform().get_package_dir("tool-avrdude") or "", "avrdude.conf"),
     ],
     FUSESFLAGS=[


### PR DESCRIPTION
spaces in the file path require quotation marks, but the current version (4.2.0) adds too many quotation marks. These small fixes restore the number of quotes.
(did something recently change in the way scons env.Replace() handles lists of strings?)
(i have not tested this in linux, but i'm hoping python/scons is consistent across platforms)