### PR TITLE
Add support for the Urboot bootloader

### DIFF
--- a/boards/AT90CAN128.json
+++ b/boards/AT90CAN128.json
@@ -18,7 +18,7 @@
   "upload": {
     "maximum_ram_size": 4096,
     "maximum_size": 131072,
-    "protocol": "arduino",
+    "protocol": "urclock",
     "require_upload_port": true,
     "speed": 115200
   },

--- a/boards/AT90CAN128.json
+++ b/boards/AT90CAN128.json
@@ -7,7 +7,9 @@
     "variant": "64-pin-avr"
   },
   "bootloader":{
-    "led_pin": "B5"
+    "led_pin": "B5",
+    "uart0_pins": "uart0_rxe0_txe1",
+    "uart1_pins": "uart1_rxd2_txd3"
   },
   "frameworks": [
     "arduino"

--- a/boards/AT90CAN32.json
+++ b/boards/AT90CAN32.json
@@ -18,7 +18,7 @@
   "upload": {
     "maximum_ram_size": 2048,
     "maximum_size": 32768,
-    "protocol": "arduino",
+    "protocol": "urclock",
     "require_upload_port": true,
     "speed": 115200
   },

--- a/boards/AT90CAN32.json
+++ b/boards/AT90CAN32.json
@@ -7,7 +7,9 @@
     "variant": "64-pin-avr"
   },
   "bootloader":{
-    "led_pin": "B5"
+    "led_pin": "B5",
+    "uart0_pins": "uart0_rxe0_txe1",
+    "uart1_pins": "uart1_rxd2_txd3"
   },
   "frameworks": [
     "arduino"

--- a/boards/AT90CAN64.json
+++ b/boards/AT90CAN64.json
@@ -18,7 +18,7 @@
   "upload": {
     "maximum_ram_size": 4096,
     "maximum_size": 65536,
-    "protocol": "arduino",
+    "protocol": "urclock",
     "require_upload_port": true,
     "speed": 115200
   },

--- a/boards/AT90CAN64.json
+++ b/boards/AT90CAN64.json
@@ -7,7 +7,9 @@
     "variant": "64-pin-avr"
   },
   "bootloader":{
-    "led_pin": "B5"
+    "led_pin": "B5",
+    "uart0_pins": "uart0_rxe0_txe1",
+    "uart1_pins": "uart1_rxd2_txd3"
   },
   "frameworks": [
     "arduino"

--- a/boards/ATmega128.json
+++ b/boards/ATmega128.json
@@ -21,7 +21,7 @@
   "upload": {
     "maximum_ram_size": 4096,
     "maximum_size": 131072,
-    "protocol": "arduino",
+    "protocol": "urclock",
     "require_upload_port": true,
     "speed": 115200
   },

--- a/boards/ATmega128.json
+++ b/boards/ATmega128.json
@@ -7,7 +7,9 @@
     "variant": "64-pin-avr"
   },
   "bootloader":{
-    "led_pin": "B5"
+    "led_pin": "B5",
+    "uart0_pins": "uart0_rxe0_txe1",
+    "uart1_pins": "uart1_rxd2_txd3"
   },
   "debug": {
     "simavr_target": "atmega128"

--- a/boards/ATmega1280.json
+++ b/boards/ATmega1280.json
@@ -26,7 +26,7 @@
   "upload": {
     "maximum_ram_size": 8192,
     "maximum_size": 131072,
-    "protocol": "arduino",
+    "protocol": "urclock",
     "require_upload_port": true,
     "speed": 115200
   },

--- a/boards/ATmega1280.json
+++ b/boards/ATmega1280.json
@@ -7,7 +7,11 @@
     "variant": "100-pin-arduino-mega"
   },
   "bootloader": {
-    "led_pin": "B7"
+    "led_pin": "B7",
+    "uart0_pins": "uart0_rxe0_txe1",
+    "uart1_pins": "uart1_rxd2_txd3",
+    "uart2_pins": "uart2_rxh0_txh1",
+    "uart3_pins": "uart3_rxj0_txj1"
   },
   "debug": {
     "simavr_target": "atmega1280",

--- a/boards/ATmega1281.json
+++ b/boards/ATmega1281.json
@@ -21,7 +21,7 @@
   "upload": {
     "maximum_ram_size": 8192,
     "maximum_size": 131072,
-    "protocol": "arduino",
+    "protocol": "urclock",
     "require_upload_port": true,
     "speed": 115200
   },

--- a/boards/ATmega1281.json
+++ b/boards/ATmega1281.json
@@ -7,7 +7,9 @@
     "variant": "64-pin-avr"
   },
   "bootloader":{
-    "led_pin": "B5"
+    "led_pin": "B5",
+    "uart0_pins": "uart0_rxe0_txe1",
+    "uart1_pins": "uart1_rxd2_txd3"
   },
   "debug": {
     "simavr_target": "atmega1281"

--- a/boards/ATmega1284.json
+++ b/boards/ATmega1284.json
@@ -7,7 +7,9 @@
     "variant": "standard"
   },
   "bootloader":{
-    "led_pin": "B0"
+    "led_pin": "B0",
+    "uart0_pins": "uart0_rxd0_txd1",
+    "uart1_pins": "uart1_rxd2_txd3"
   },
   "debug": {
     "simavr_target": "atmega1284"

--- a/boards/ATmega1284.json
+++ b/boards/ATmega1284.json
@@ -21,7 +21,7 @@
   "upload": {
     "maximum_ram_size": 16384,
     "maximum_size": 131072,
-    "protocol": "arduino",
+    "protocol": "urclock",
     "require_upload_port": true,
     "speed": 115200
   },

--- a/boards/ATmega1284P.json
+++ b/boards/ATmega1284P.json
@@ -7,7 +7,9 @@
     "variant": "standard"
   },
   "bootloader":{
-    "led_pin": "B0"
+    "led_pin": "B0",
+    "uart0_pins": "uart0_rxd0_txd1",
+    "uart1_pins": "uart1_rxd2_txd3"
   },
   "debug": {
     "simavr_target": "atmega1284p"

--- a/boards/ATmega1284P.json
+++ b/boards/ATmega1284P.json
@@ -21,7 +21,7 @@
   "upload": {
     "maximum_ram_size": 16384,
     "maximum_size": 131072,
-    "protocol": "arduino",
+    "protocol": "urclock",
     "require_upload_port": true,
     "speed": 115200
   },

--- a/boards/ATmega16.json
+++ b/boards/ATmega16.json
@@ -20,7 +20,7 @@
   "upload": {
     "maximum_ram_size": 1024,
     "maximum_size": 16384,
-    "protocol": "arduino",
+    "protocol": "urclock",
     "require_upload_port": true,
     "speed": 115200
   },

--- a/boards/ATmega16.json
+++ b/boards/ATmega16.json
@@ -7,7 +7,8 @@
     "variant": "standard"
   },
   "bootloader":{
-    "led_pin": "B0"
+    "led_pin": "B0",
+    "uart0_pins": "uart0_rxd0_txd1"
   },
   "debug": {
     "simavr_target": "atmega16"

--- a/boards/ATmega162.json
+++ b/boards/ATmega162.json
@@ -18,7 +18,7 @@
   "upload": {
     "maximum_ram_size": 1024,
     "maximum_size": 16384,
-    "protocol": "arduino",
+    "protocol": "urclock",
     "require_upload_port": true,
     "speed": 115200
   },

--- a/boards/ATmega162.json
+++ b/boards/ATmega162.json
@@ -7,7 +7,9 @@
     "variant": "standard"
   },
   "bootloader":{
-    "led_pin": "B0"
+    "led_pin": "B0",
+    "uart0_pins": "uart0_rxd0_txd1",
+    "uart1_pins": "uart1_rxb2_txb3"
   },
   "frameworks": [
     "arduino"

--- a/boards/ATmega164A.json
+++ b/boards/ATmega164A.json
@@ -18,7 +18,7 @@
   "upload": {
     "maximum_ram_size": 1024,
     "maximum_size": 16384,
-    "protocol": "arduino",
+    "protocol": "urclock",
     "require_upload_port": true,
     "speed": 115200
   },

--- a/boards/ATmega164A.json
+++ b/boards/ATmega164A.json
@@ -7,7 +7,9 @@
     "variant": "standard"
   },
   "bootloader":{
-    "led_pin": "B0"
+    "led_pin": "B0",
+    "uart0_pins": "uart0_rxd0_txd1",
+    "uart1_pins": "uart1_rxd2_txd3"
   },
   "frameworks": [
     "arduino"

--- a/boards/ATmega164P.json
+++ b/boards/ATmega164P.json
@@ -21,7 +21,7 @@
   "upload": {
     "maximum_ram_size": 1024,
     "maximum_size": 16384,
-    "protocol": "arduino",
+    "protocol": "urclock",
     "require_upload_port": true,
     "speed": 115200
   },

--- a/boards/ATmega164P.json
+++ b/boards/ATmega164P.json
@@ -7,7 +7,9 @@
     "variant": "standard"
   },
   "bootloader":{
-    "led_pin": "B0"
+    "led_pin": "B0",
+    "uart0_pins": "uart0_rxd0_txd1",
+    "uart1_pins": "uart1_rxd2_txd3"
   },
   "debug": {
     "simavr_target": "atmega164p"

--- a/boards/ATmega165.json
+++ b/boards/ATmega165.json
@@ -17,7 +17,7 @@
   "upload": {
     "maximum_ram_size": 1024,
     "maximum_size": 16384,
-    "protocol": "arduino",
+    "protocol": "urclock",
     "require_upload_port": true,
     "speed": 115200
   },

--- a/boards/ATmega165.json
+++ b/boards/ATmega165.json
@@ -7,7 +7,8 @@
     "variant": "64-pin-avr"
   },
   "bootloader":{
-    "led_pin": "B5"
+    "led_pin": "B5",
+    "uart0_pins": "uart0_rxe0_txe1"
   },
   "frameworks": [
     "arduino"

--- a/boards/ATmega165P.json
+++ b/boards/ATmega165P.json
@@ -17,7 +17,7 @@
   "upload": {
     "maximum_ram_size": 1024,
     "maximum_size": 16384,
-    "protocol": "arduino",
+    "protocol": "urclock",
     "require_upload_port": true,
     "speed": 115200
   },

--- a/boards/ATmega165P.json
+++ b/boards/ATmega165P.json
@@ -7,7 +7,8 @@
     "variant": "64-pin-avr"
   },
   "bootloader":{
-    "led_pin": "B5"
+    "led_pin": "B5",
+    "uart0_pins": "uart0_rxe0_txe1"
   },
   "frameworks": [
     "arduino"

--- a/boards/ATmega168.json
+++ b/boards/ATmega168.json
@@ -20,7 +20,7 @@
   "upload": {
     "maximum_ram_size": 1024,
     "maximum_size": 16384,
-    "protocol": "arduino",
+    "protocol": "urclock",
     "require_upload_port": true,
     "speed": 115200
   },

--- a/boards/ATmega168.json
+++ b/boards/ATmega168.json
@@ -7,7 +7,8 @@
     "variant": "standard"
   },
   "bootloader":{
-    "led_pin": "B5"
+    "led_pin": "B5",
+    "uart0_pins": "uart0_rxd0_txd1"
   },
   "debug": {
     "simavr_target": "atmega168"

--- a/boards/ATmega168P.json
+++ b/boards/ATmega168P.json
@@ -20,7 +20,7 @@
   "upload": {
     "maximum_ram_size": 1024,
     "maximum_size": 16384,
-    "protocol": "arduino",
+    "protocol": "urclock",
     "require_upload_port": true,
     "speed": 115200
   },

--- a/boards/ATmega168P.json
+++ b/boards/ATmega168P.json
@@ -7,7 +7,8 @@
     "variant": "standard"
   },
   "bootloader":{
-    "led_pin": "B5"
+    "led_pin": "B5",
+    "uart0_pins": "uart0_rxd0_txd1"
   },
   "debug": {
     "simavr_target": "atmega168p"

--- a/boards/ATmega168PB.json
+++ b/boards/ATmega168PB.json
@@ -17,7 +17,7 @@
   "upload": {
     "maximum_ram_size": 1024,
     "maximum_size": 16384,
-    "protocol": "arduino",
+    "protocol": "urclock",
     "require_upload_port": true,
     "speed": 115200
   },

--- a/boards/ATmega168PB.json
+++ b/boards/ATmega168PB.json
@@ -7,7 +7,8 @@
     "variant": "pb-variant"
   },
   "bootloader":{
-    "led_pin": "B5"
+    "led_pin": "B5",
+    "uart0_pins": "uart0_rxd0_txd1"
   },
   "frameworks": [
     "arduino"

--- a/boards/ATmega169A.json
+++ b/boards/ATmega169A.json
@@ -17,7 +17,7 @@
   "upload": {
     "maximum_ram_size": 1024,
     "maximum_size": 16384,
-    "protocol": "arduino",
+    "protocol": "urclock",
     "require_upload_port": true,
     "speed": 115200
   },

--- a/boards/ATmega169A.json
+++ b/boards/ATmega169A.json
@@ -7,7 +7,8 @@
     "variant": "64-pin-avr"
   },
   "bootloader":{
-    "led_pin": "B5"
+    "led_pin": "B5",
+    "uart0_pins": "uart0_rxe0_txe1"
   },
   "frameworks": [
     "arduino"

--- a/boards/ATmega169P.json
+++ b/boards/ATmega169P.json
@@ -17,7 +17,7 @@
   "upload": {
     "maximum_ram_size": 1024,
     "maximum_size": 16384,
-    "protocol": "arduino",
+    "protocol": "urclock",
     "require_upload_port": true,
     "speed": 115200
   },

--- a/boards/ATmega169P.json
+++ b/boards/ATmega169P.json
@@ -7,7 +7,8 @@
     "variant": "64-pin-avr"
   },
   "bootloader":{
-    "led_pin": "B5"
+    "led_pin": "B5",
+    "uart0_pins": "uart0_rxe0_txe1"
   },
   "frameworks": [
     "arduino"

--- a/boards/ATmega2560.json
+++ b/boards/ATmega2560.json
@@ -7,7 +7,11 @@
     "variant": "100-pin-arduino-mega"
   },
   "bootloader": {
-    "led_pin": "B7"
+    "led_pin": "B7",
+    "uart0_pins": "uart0_rxe0_txe1",
+    "uart1_pins": "uart1_rxd2_txd3",
+    "uart2_pins": "uart2_rxh0_txh1",
+    "uart3_pins": "uart3_rxj0_txj1"
   },
   "debug": {
     "simavr_target": "atmega2560",

--- a/boards/ATmega2560.json
+++ b/boards/ATmega2560.json
@@ -26,7 +26,7 @@
   "upload": {
     "maximum_ram_size": 8192,
     "maximum_size": 262144,
-    "protocol": "arduino",
+    "protocol": "urclock",
     "require_upload_port": true,
     "speed": 115200
   },

--- a/boards/ATmega2561.json
+++ b/boards/ATmega2561.json
@@ -18,7 +18,7 @@
   "upload": {
     "maximum_ram_size": 8192,
     "maximum_size": 262144,
-    "protocol": "arduino",
+    "protocol": "urclock",
     "require_upload_port": true,
     "speed": 115200
   },

--- a/boards/ATmega2561.json
+++ b/boards/ATmega2561.json
@@ -7,7 +7,9 @@
     "variant": "64-pin-avr"
   },
   "bootloader":{
-    "led_pin": "B5"
+    "led_pin": "B5",
+    "uart0_pins": "uart0_rxe0_txe1",
+    "uart1_pins": "uart1_rxd2_txd3"
   },
   "frameworks": [
     "arduino"

--- a/boards/ATmega32.json
+++ b/boards/ATmega32.json
@@ -7,7 +7,8 @@
     "variant": "standard"
   },
   "bootloader":{
-    "led_pin": "B0"
+    "led_pin": "B0",
+    "uart0_pins": "uart0_rxd0_txd1"
   },
   "frameworks": [
     "arduino"

--- a/boards/ATmega32.json
+++ b/boards/ATmega32.json
@@ -17,7 +17,7 @@
   "upload": {
     "maximum_ram_size": 2048,
     "maximum_size": 32768,
-    "protocol": "arduino",
+    "protocol": "urclock",
     "require_upload_port": true,
     "speed": 115200
   },

--- a/boards/ATmega324A.json
+++ b/boards/ATmega324A.json
@@ -21,7 +21,7 @@
   "upload": {
     "maximum_ram_size": 2048,
     "maximum_size": 32768,
-    "protocol": "arduino",
+    "protocol": "urclock",
     "require_upload_port": true,
     "speed": 115200
   },

--- a/boards/ATmega324A.json
+++ b/boards/ATmega324A.json
@@ -7,7 +7,9 @@
     "variant": "standard"
   },
   "bootloader":{
-    "led_pin": "B0"
+    "led_pin": "B0",
+    "uart0_pins": "uart0_rxd0_txd1",
+    "uart1_pins": "uart1_rxd2_txd3"
   },
   "debug": {
     "simavr_target": "atmega324a"

--- a/boards/ATmega324P.json
+++ b/boards/ATmega324P.json
@@ -21,7 +21,7 @@
   "upload": {
     "maximum_ram_size": 2048,
     "maximum_size": 32768,
-    "protocol": "arduino",
+    "protocol": "urclock",
     "require_upload_port": true,
     "speed": 115200
   },

--- a/boards/ATmega324P.json
+++ b/boards/ATmega324P.json
@@ -7,7 +7,9 @@
     "variant": "standard"
   },
   "bootloader":{
-    "led_pin": "B0"
+    "led_pin": "B0",
+    "uart0_pins": "uart0_rxd0_txd1",
+    "uart1_pins": "uart1_rxd2_txd3"
   },
   "debug": {
     "simavr_target": "atmega324p"

--- a/boards/ATmega324PA.json
+++ b/boards/ATmega324PA.json
@@ -21,7 +21,7 @@
   "upload": {
     "maximum_ram_size": 2048,
     "maximum_size": 32768,
-    "protocol": "arduino",
+    "protocol": "urclock",
     "require_upload_port": true,
     "speed": 115200
   },

--- a/boards/ATmega324PA.json
+++ b/boards/ATmega324PA.json
@@ -7,7 +7,9 @@
     "variant": "standard"
   },
   "bootloader":{
-    "led_pin": "B0"
+    "led_pin": "B0",
+    "uart0_pins": "uart0_rxd0_txd1",
+    "uart1_pins": "uart1_rxd2_txd3"
   },
   "debug": {
     "simavr_target": "atmega324pa"

--- a/boards/ATmega324PB.json
+++ b/boards/ATmega324PB.json
@@ -19,7 +19,7 @@
   "upload": {
     "maximum_ram_size": 2048,
     "maximum_size": 32768,
-    "protocol": "arduino",
+    "protocol": "urclock",
     "require_upload_port": true,
     "speed": 115200
   },

--- a/boards/ATmega324PB.json
+++ b/boards/ATmega324PB.json
@@ -7,7 +7,10 @@
     "variant": "standard"
   },
   "bootloader":{
-    "led_pin": "B0"
+    "led_pin": "B0",
+    "uart0_pins": "uart0_rxd0_txd1",
+    "uart1_pins": "uart1_rxd2_txd3",
+    "uart2_pins": "uart2_rxe2_txe3"
   },
   "frameworks": [
     "arduino"

--- a/boards/ATmega325.json
+++ b/boards/ATmega325.json
@@ -7,7 +7,8 @@
     "variant": "64-pin-avr"
   },
   "bootloader":{
-    "led_pin": "B5"
+    "led_pin": "B5",
+    "uart0_pins": "uart0_rxe0_txe1"
   },
   "frameworks": [
     "arduino"

--- a/boards/ATmega325.json
+++ b/boards/ATmega325.json
@@ -17,7 +17,7 @@
   "upload": {
     "maximum_ram_size": 2048,
     "maximum_size": 32768,
-    "protocol": "arduino",
+    "protocol": "urclock",
     "require_upload_port": true,
     "speed": 115200
   },

--- a/boards/ATmega3250.json
+++ b/boards/ATmega3250.json
@@ -7,7 +7,8 @@
     "variant": "100-pin-avr"
   },
   "bootloader":{
-    "led_pin": "B7"
+    "led_pin": "B7",
+    "uart0_pins": "uart0_rxe0_txe1"
   },
   "frameworks": [
     "arduino"

--- a/boards/ATmega3250.json
+++ b/boards/ATmega3250.json
@@ -17,7 +17,7 @@
   "upload": {
     "maximum_ram_size": 2048,
     "maximum_size": 32768,
-    "protocol": "arduino",
+    "protocol": "urclock",
     "require_upload_port": true,
     "speed": 115200
   },

--- a/boards/ATmega3250P.json
+++ b/boards/ATmega3250P.json
@@ -7,7 +7,8 @@
     "variant": "100-pin-avr"
   },
   "bootloader":{
-    "led_pin": "B7"
+    "led_pin": "B7",
+    "uart0_pins": "uart0_rxe0_txe1"
   },
   "frameworks": [
     "arduino"

--- a/boards/ATmega3250P.json
+++ b/boards/ATmega3250P.json
@@ -17,7 +17,7 @@
   "upload": {
     "maximum_ram_size": 2048,
     "maximum_size": 32768,
-    "protocol": "arduino",
+    "protocol": "urclock",
     "require_upload_port": true,
     "speed": 115200
   },

--- a/boards/ATmega325P.json
+++ b/boards/ATmega325P.json
@@ -7,7 +7,8 @@
     "variant": "64-pin-avr"
   },
   "bootloader":{
-    "led_pin": "B5"
+    "led_pin": "B5",
+    "uart0_pins": "uart0_rxe0_txe1"
   },
   "frameworks": [
     "arduino"

--- a/boards/ATmega325P.json
+++ b/boards/ATmega325P.json
@@ -17,7 +17,7 @@
   "upload": {
     "maximum_ram_size": 2048,
     "maximum_size": 32768,
-    "protocol": "arduino",
+    "protocol": "urclock",
     "require_upload_port": true,
     "speed": 115200
   },

--- a/boards/ATmega328.json
+++ b/boards/ATmega328.json
@@ -23,7 +23,7 @@
   "upload": {
     "maximum_ram_size": 2048,
     "maximum_size": 32768,
-    "protocol": "arduino",
+    "protocol": "urclock",
     "require_upload_port": true,
     "speed": 115200
   },

--- a/boards/ATmega328.json
+++ b/boards/ATmega328.json
@@ -7,7 +7,8 @@
     "variant": "standard"
   },
   "bootloader": {
-    "led_pin": "B5"
+    "led_pin": "B5",
+    "uart0_pins": "uart0_rxd0_txd1"
   },
   "debug": {
     "simavr_target": "atmega328",

--- a/boards/ATmega328P.json
+++ b/boards/ATmega328P.json
@@ -23,7 +23,7 @@
   "upload": {
     "maximum_ram_size": 2048,
     "maximum_size": 32768,
-    "protocol": "arduino",
+    "protocol": "urclock",
     "require_upload_port": true,
     "speed": 115200
   },

--- a/boards/ATmega328P.json
+++ b/boards/ATmega328P.json
@@ -7,7 +7,8 @@
     "variant": "standard"
   },
   "bootloader": {
-    "led_pin": "B5"
+    "led_pin": "B5",
+    "uart0_pins": "uart0_rxd0_txd1"
   },
   "debug": {
     "simavr_target": "atmega328p",

--- a/boards/ATmega328PB.json
+++ b/boards/ATmega328PB.json
@@ -18,7 +18,7 @@
   "upload": {
     "maximum_ram_size": 2048,
     "maximum_size": 32768,
-    "protocol": "arduino",
+    "protocol": "urclock",
     "require_upload_port": true,
     "speed": 115200
   },

--- a/boards/ATmega328PB.json
+++ b/boards/ATmega328PB.json
@@ -7,7 +7,9 @@
     "variant": "pb-variant"
   },
   "bootloader":{
-    "led_pin": "B5"
+    "led_pin": "B5",
+    "uart0_pins": "uart0_rxd0_txd1",
+    "uart1_pins": "uart1_rxb4_txb3"
   },
   "frameworks": [
     "arduino"

--- a/boards/ATmega329.json
+++ b/boards/ATmega329.json
@@ -7,7 +7,8 @@
     "variant": "64-pin-avr"
   },
   "bootloader":{
-    "led_pin": "B5"
+    "led_pin": "B5",
+    "uart0_pins": "uart0_rxe0_txe1"
   },
   "frameworks": [
     "arduino"

--- a/boards/ATmega329.json
+++ b/boards/ATmega329.json
@@ -17,7 +17,7 @@
   "upload": {
     "maximum_ram_size": 2048,
     "maximum_size": 32768,
-    "protocol": "arduino",
+    "protocol": "urclock",
     "require_upload_port": true,
     "speed": 115200
   },

--- a/boards/ATmega3290.json
+++ b/boards/ATmega3290.json
@@ -7,7 +7,8 @@
     "variant": "100-pin-avr"
   },
   "bootloader":{
-    "led_pin": "B7"
+    "led_pin": "B7",
+    "uart0_pins": "uart0_rxe0_txe1"
   },
   "frameworks": [
     "arduino"

--- a/boards/ATmega3290.json
+++ b/boards/ATmega3290.json
@@ -17,7 +17,7 @@
   "upload": {
     "maximum_ram_size": 2048,
     "maximum_size": 32768,
-    "protocol": "arduino",
+    "protocol": "urclock",
     "require_upload_port": true,
     "speed": 115200
   },

--- a/boards/ATmega3290P.json
+++ b/boards/ATmega3290P.json
@@ -7,7 +7,8 @@
     "variant": "100-pin-avr"
   },
   "bootloader":{
-    "led_pin": "B7"
+    "led_pin": "B7",
+    "uart0_pins": "uart0_rxe0_txe1"
   },
   "frameworks": [
     "arduino"

--- a/boards/ATmega3290P.json
+++ b/boards/ATmega3290P.json
@@ -17,7 +17,7 @@
   "upload": {
     "maximum_ram_size": 2048,
     "maximum_size": 32768,
-    "protocol": "arduino",
+    "protocol": "urclock",
     "require_upload_port": true,
     "speed": 115200
   },

--- a/boards/ATmega329P.json
+++ b/boards/ATmega329P.json
@@ -7,7 +7,8 @@
     "variant": "64-pin-avr"
   },
   "bootloader":{
-    "led_pin": "B5"
+    "led_pin": "B5",
+    "uart0_pins": "uart0_rxe0_txe1"
   },
   "frameworks": [
     "arduino"

--- a/boards/ATmega329P.json
+++ b/boards/ATmega329P.json
@@ -17,7 +17,7 @@
   "upload": {
     "maximum_ram_size": 2048,
     "maximum_size": 32768,
-    "protocol": "arduino",
+    "protocol": "urclock",
     "require_upload_port": true,
     "speed": 115200
   },

--- a/boards/ATmega48.json
+++ b/boards/ATmega48.json
@@ -7,7 +7,8 @@
     "variant": "standard"
   },
   "bootloader":{
-    "led_pin": "B5"
+    "led_pin": "B5",
+    "uart0_pins": "uart0_rxd0_txd1"
   },
   "debug": {
     "simavr_target": "atmega48"

--- a/boards/ATmega48.json
+++ b/boards/ATmega48.json
@@ -20,7 +20,7 @@
   "upload": {
     "maximum_ram_size": 512,
     "maximum_size": 4096,
-    "protocol": "arduino",
+    "protocol": "urclock",
     "require_upload_port": false
   },
   "url": "https://www.microchip.com/wwwproducts/en/ATmega48",

--- a/boards/ATmega48P.json
+++ b/boards/ATmega48P.json
@@ -7,7 +7,8 @@
     "variant": "standard"
   },
   "bootloader":{
-    "led_pin": "B5"
+    "led_pin": "B5",
+    "uart0_pins": "uart0_rxd0_txd1"
   },
   "debug": {
     "simavr_target": "atmega48p"

--- a/boards/ATmega48P.json
+++ b/boards/ATmega48P.json
@@ -20,7 +20,7 @@
   "upload": {
     "maximum_ram_size": 512,
     "maximum_size": 4096,
-    "protocol": "arduino",
+    "protocol": "urclock",
     "require_upload_port": false
   },
   "url": "https://www.microchip.com/wwwproducts/en/ATmega48P",

--- a/boards/ATmega48PB.json
+++ b/boards/ATmega48PB.json
@@ -7,7 +7,8 @@
     "variant": "pb-variant"
   },
   "bootloader":{
-    "led_pin": "B5"
+    "led_pin": "B5",
+    "uart0_pins": "uart0_rxd0_txd1"
   },
   "frameworks": [
     "arduino"

--- a/boards/ATmega48PB.json
+++ b/boards/ATmega48PB.json
@@ -17,7 +17,7 @@
   "upload": {
     "maximum_ram_size": 512,
     "maximum_size": 4096,
-    "protocol": "arduino",
+    "protocol": "urclock",
     "require_upload_port": false
   },
   "url": "https://www.microchip.com/wwwproducts/en/ATmega48PB",

--- a/boards/ATmega64.json
+++ b/boards/ATmega64.json
@@ -18,7 +18,7 @@
   "upload": {
     "maximum_ram_size": 4096,
     "maximum_size": 65536,
-    "protocol": "arduino",
+    "protocol": "urclock",
     "require_upload_port": true,
     "speed": 115200
   },

--- a/boards/ATmega64.json
+++ b/boards/ATmega64.json
@@ -7,7 +7,9 @@
     "variant": "64-pin-avr"
   },
   "bootloader":{
-    "led_pin": "B5"
+    "led_pin": "B5",
+    "uart0_pins": "uart0_rxe0_txe1",
+    "uart1_pins": "uart1_rxd2_txd3"
   },
   "frameworks": [
     "arduino"

--- a/boards/ATmega640.json
+++ b/boards/ATmega640.json
@@ -20,7 +20,7 @@
   "upload": {
     "maximum_ram_size": 8192,
     "maximum_size": 65536,
-    "protocol": "arduino",
+    "protocol": "urclock",
     "require_upload_port": true,
     "speed": 115200
   },

--- a/boards/ATmega640.json
+++ b/boards/ATmega640.json
@@ -7,7 +7,11 @@
     "variant": "100-pin-arduino-mega"
   },
   "bootloader":{
-    "led_pin": "B7"
+    "led_pin": "B7",
+    "uart0_pins": "uart0_rxe0_txe1",
+    "uart1_pins": "uart1_rxd2_txd3",
+    "uart2_pins": "uart2_rxh0_txh1",
+    "uart3_pins": "uart3_rxj0_txj1"
   },
   "frameworks": [
     "arduino"

--- a/boards/ATmega644A.json
+++ b/boards/ATmega644A.json
@@ -7,7 +7,9 @@
     "variant": "standard"
   },
   "bootloader":{
-    "led_pin": "B0"
+    "led_pin": "B0",
+    "uart0_pins": "uart0_rxd0_txd1",
+    "uart1_pins": "uart1_rxd2_txd3"
   },
   "frameworks": [
     "arduino"

--- a/boards/ATmega644A.json
+++ b/boards/ATmega644A.json
@@ -18,7 +18,7 @@
   "upload": {
     "maximum_ram_size": 4096,
     "maximum_size": 65536,
-    "protocol": "arduino",
+    "protocol": "urclock",
     "require_upload_port": true,
     "speed": 115200
   },

--- a/boards/ATmega644P.json
+++ b/boards/ATmega644P.json
@@ -21,7 +21,7 @@
   "upload": {
     "maximum_ram_size": 4096,
     "maximum_size": 65536,
-    "protocol": "arduino",
+    "protocol": "urclock",
     "require_upload_port": true,
     "speed": 115200
   },

--- a/boards/ATmega644P.json
+++ b/boards/ATmega644P.json
@@ -7,7 +7,9 @@
     "variant": "standard"
   },
   "bootloader":{
-    "led_pin": "B0"
+    "led_pin": "B0",
+    "uart0_pins": "uart0_rxd0_txd1",
+    "uart1_pins": "uart1_rxd2_txd3"
   },
   "debug": {
     "simavr_target": "atmega644p"

--- a/boards/ATmega645.json
+++ b/boards/ATmega645.json
@@ -17,7 +17,7 @@
   "upload": {
     "maximum_ram_size": 4096,
     "maximum_size": 65536,
-    "protocol": "arduino",
+    "protocol": "urclock",
     "require_upload_port": true,
     "speed": 115200
   },

--- a/boards/ATmega645.json
+++ b/boards/ATmega645.json
@@ -7,7 +7,8 @@
     "variant": "64-pin-avr"
   },
   "bootloader":{
-    "led_pin": "B5"
+    "led_pin": "B5",
+    "uart0_pins": "uart0_rxe0_txe1"
   },
   "frameworks": [
     "arduino"

--- a/boards/ATmega6450.json
+++ b/boards/ATmega6450.json
@@ -17,7 +17,7 @@
   "upload": {
     "maximum_ram_size": 4096,
     "maximum_size": 65536,
-    "protocol": "arduino",
+    "protocol": "urclock",
     "require_upload_port": true,
     "speed": 115200
   },

--- a/boards/ATmega6450.json
+++ b/boards/ATmega6450.json
@@ -7,7 +7,8 @@
     "variant": "100-pin-avr"
   },
   "bootloader":{
-    "led_pin": "B7"
+    "led_pin": "B7",
+    "uart0_pins": "uart0_rxe0_txe1"
   },
   "frameworks": [
     "arduino"

--- a/boards/ATmega6450P.json
+++ b/boards/ATmega6450P.json
@@ -17,7 +17,7 @@
   "upload": {
     "maximum_ram_size": 4096,
     "maximum_size": 65536,
-    "protocol": "arduino",
+    "protocol": "urclock",
     "require_upload_port": true,
     "speed": 115200
   },

--- a/boards/ATmega6450P.json
+++ b/boards/ATmega6450P.json
@@ -7,7 +7,8 @@
     "variant": "100-pin-avr"
   },
   "bootloader":{
-    "led_pin": "B7"
+    "led_pin": "B7",
+    "uart0_pins": "uart0_rxe0_txe1"
   },
   "frameworks": [
     "arduino"

--- a/boards/ATmega645P.json
+++ b/boards/ATmega645P.json
@@ -17,7 +17,7 @@
   "upload": {
     "maximum_ram_size": 4096,
     "maximum_size": 65536,
-    "protocol": "arduino",
+    "protocol": "urclock",
     "require_upload_port": true,
     "speed": 115200
   },

--- a/boards/ATmega645P.json
+++ b/boards/ATmega645P.json
@@ -7,7 +7,8 @@
     "variant": "64-pin-avr"
   },
   "bootloader":{
-    "led_pin": "B5"
+    "led_pin": "B5",
+    "uart0_pins": "uart0_rxe0_txe1"
   },
   "frameworks": [
     "arduino"

--- a/boards/ATmega649.json
+++ b/boards/ATmega649.json
@@ -17,7 +17,7 @@
   "upload": {
     "maximum_ram_size": 4096,
     "maximum_size": 65536,
-    "protocol": "arduino",
+    "protocol": "urclock",
     "require_upload_port": true,
     "speed": 115200
   },

--- a/boards/ATmega649.json
+++ b/boards/ATmega649.json
@@ -7,7 +7,8 @@
     "variant": "64-pin-avr"
   },
   "bootloader":{
-    "led_pin": "B5"
+    "led_pin": "B5",
+    "uart0_pins": "uart0_rxe0_txe1"
   },
   "frameworks": [
     "arduino"

--- a/boards/ATmega6490.json
+++ b/boards/ATmega6490.json
@@ -17,7 +17,7 @@
   "upload": {
     "maximum_ram_size": 4096,
     "maximum_size": 65536,
-    "protocol": "arduino",
+    "protocol": "urclock",
     "require_upload_port": true,
     "speed": 115200
   },

--- a/boards/ATmega6490.json
+++ b/boards/ATmega6490.json
@@ -7,7 +7,8 @@
     "variant": "100-pin-avr"
   },
   "bootloader":{
-    "led_pin": "B7"
+    "led_pin": "B7",
+    "uart0_pins": "uart0_rxe0_txe1"
   },
   "frameworks": [
     "arduino"

--- a/boards/ATmega6490P.json
+++ b/boards/ATmega6490P.json
@@ -17,7 +17,7 @@
   "upload": {
     "maximum_ram_size": 4096,
     "maximum_size": 65536,
-    "protocol": "arduino",
+    "protocol": "urclock",
     "require_upload_port": true,
     "speed": 115200
   },

--- a/boards/ATmega6490P.json
+++ b/boards/ATmega6490P.json
@@ -7,7 +7,8 @@
     "variant": "100-pin-avr"
   },
   "bootloader":{
-    "led_pin": "B7"
+    "led_pin": "B7",
+    "uart0_pins": "uart0_rxe0_txe1"
   },
   "frameworks": [
     "arduino"

--- a/boards/ATmega649P.json
+++ b/boards/ATmega649P.json
@@ -17,7 +17,7 @@
   "upload": {
     "maximum_ram_size": 4096,
     "maximum_size": 65536,
-    "protocol": "arduino",
+    "protocol": "urclock",
     "require_upload_port": true,
     "speed": 115200
   },

--- a/boards/ATmega649P.json
+++ b/boards/ATmega649P.json
@@ -7,7 +7,8 @@
     "variant": "64-pin-avr"
   },
   "bootloader":{
-    "led_pin": "B5"
+    "led_pin": "B5",
+    "uart0_pins": "uart0_rxe0_txe1"
   },
   "frameworks": [
     "arduino"

--- a/boards/ATmega8.json
+++ b/boards/ATmega8.json
@@ -7,7 +7,8 @@
     "variant": "standard"
   },
   "bootloader":{
-    "led_pin": "B5"
+    "led_pin": "B5",
+    "uart0_pins": "uart0_rxd0_txd1"
   },
   "debug": {
     "simavr_target": "atmega8"

--- a/boards/ATmega8.json
+++ b/boards/ATmega8.json
@@ -20,7 +20,7 @@
   "upload": {
     "maximum_ram_size": 1024,
     "maximum_size": 8192,
-    "protocol": "arduino",
+    "protocol": "urclock",
     "require_upload_port": true,
     "speed": 115200
   },

--- a/boards/ATmega8515.json
+++ b/boards/ATmega8515.json
@@ -17,7 +17,7 @@
   "upload": {
     "maximum_ram_size": 512,
     "maximum_size": 8192,
-    "protocol": "arduino",
+    "protocol": "urclock",
     "require_upload_port": true,
     "speed": 115200
   },

--- a/boards/ATmega8515.json
+++ b/boards/ATmega8515.json
@@ -7,7 +7,8 @@
     "variant": "standard"
   },
   "bootloader":{
-    "led_pin": "B0"
+    "led_pin": "B0",
+    "uart0_pins": "uart0_rxd0_txd1"
   },
   "frameworks": [
     "arduino"

--- a/boards/ATmega8535.json
+++ b/boards/ATmega8535.json
@@ -17,7 +17,7 @@
   "upload": {
     "maximum_ram_size": 512,
     "maximum_size": 8192,
-    "protocol": "arduino",
+    "protocol": "urclock",
     "require_upload_port": true,
     "speed": 115200
   },

--- a/boards/ATmega8535.json
+++ b/boards/ATmega8535.json
@@ -7,7 +7,8 @@
     "variant": "standard"
   },
   "bootloader":{
-    "led_pin": "B0"
+    "led_pin": "B0",
+    "uart0_pins": "uart0_rxd0_txd1"
   },
   "frameworks": [
     "arduino"

--- a/boards/ATmega88.json
+++ b/boards/ATmega88.json
@@ -7,7 +7,8 @@
     "variant": "standard"
   },
   "bootloader":{
-    "led_pin": "B5"
+    "led_pin": "B5",
+    "uart0_pins": "uart0_rxd0_txd1"
   },
   "debug": {
     "simavr_target": "atmega88"

--- a/boards/ATmega88.json
+++ b/boards/ATmega88.json
@@ -20,7 +20,7 @@
   "upload": {
     "maximum_ram_size": 1024,
     "maximum_size": 8192,
-    "protocol": "arduino",
+    "protocol": "urclock",
     "require_upload_port": true,
     "speed": 115200
   },

--- a/boards/ATmega88P.json
+++ b/boards/ATmega88P.json
@@ -7,7 +7,8 @@
     "variant": "standard"
   },
   "bootloader":{
-    "led_pin": "B5"
+    "led_pin": "B5",
+    "uart0_pins": "uart0_rxd0_txd1"
   },
   "debug": {
     "simavr_target": "atmega88p"

--- a/boards/ATmega88P.json
+++ b/boards/ATmega88P.json
@@ -20,7 +20,7 @@
   "upload": {
     "maximum_ram_size": 1024,
     "maximum_size": 8192,
-    "protocol": "arduino",
+    "protocol": "urclock",
     "require_upload_port": true,
     "speed": 115200
   },

--- a/boards/ATmega88PB.json
+++ b/boards/ATmega88PB.json
@@ -17,7 +17,7 @@
   "upload": {
     "maximum_ram_size": 1024,
     "maximum_size": 8192,
-    "protocol": "arduino",
+    "protocol": "urclock",
     "require_upload_port": true,
     "speed": 115200
   },

--- a/boards/ATmega88PB.json
+++ b/boards/ATmega88PB.json
@@ -7,7 +7,8 @@
     "variant": "pb-variant"
   },
   "bootloader":{
-    "led_pin": "B5"
+    "led_pin": "B5",
+    "uart0_pins": "uart0_rxd0_txd1"
   },
   "frameworks": [
     "arduino"

--- a/builder/bootloader.py
+++ b/builder/bootloader.py
@@ -61,10 +61,10 @@ def get_suitable_urboot_binary(framework_dir, board_config):
     bootloader_speed = board_config.get("bootloader.speed", env.subst("$UPLOAD_SPEED"))
 
     if core == "MicroCore":
-        bootloader_file = "urboot_%s.hex" % mcu
+        bootloader_file = "urboot_attiny13a.hex"
         bootloader_led = board_config.get("bootloader.led_pin", "no-led").lower()
         f_cpu_error = float(board_config.get("hardware.f_cpu_error", "0.0"))
-        uart_pins = board_config.get("hardware.uart", "swio_rxb1_txb0").lower()
+        uart_pins = board_config.get("bootloader.uart_pins", "swio_rxb1_txb0").lower()
         if oscillator == "internal":
             clock_speed = f_cpu + int(f_cpu_error / 100 * f_cpu)
         else:

--- a/builder/bootloader.py
+++ b/builder/bootloader.py
@@ -83,6 +83,13 @@ def get_suitable_urboot_binary(framework_dir, board_config):
             bootloader_file,
         )
 
+        if (f_cpu_error < -10.00 or f_cpu_error > 10.00 or f_cpu_error % 1.25 != 0.0):
+            sys.stderr.write(
+                "Error: invalid f_cpu factor %.2f. Must me in steps of ±1.25 and within ±10.00\n"
+                % f_cpu_error
+            )
+            env.Exit(1)
+
     elif core in ("MightyCore", "MegaCore", "MiniCore", "MajorCore"):
         bootloader_file = "urboot_%s_pr_ee_ce.hex" % mcu
         user_led = board_config.get("bootloader.led_pin", "no-led").lower()

--- a/builder/bootloader.py
+++ b/builder/bootloader.py
@@ -83,7 +83,7 @@ def get_suitable_urboot_binary(framework_dir, board_config):
             bootloader_file,
         )
 
-        if (f_cpu_error < -10.00 or f_cpu_error > 10.00 or f_cpu_error % 1.25 != 0.0):
+        if -10.00 > f_cpu_error > 10.00 or f_cpu_error % 1.25 != 0.0:
             sys.stderr.write(
                 "Error: invalid f_cpu factor %.2f. Must me in steps of ±1.25 and within ±10.00\n"
                 % f_cpu_error

--- a/builder/bootloader.py
+++ b/builder/bootloader.py
@@ -57,34 +57,82 @@ def get_suitable_optiboot_binary(framework_dir, board_config):
 def get_suitable_urboot_binary(framework_dir, board_config):
     mcu = board_config.get("build.mcu", "").lower()
     f_cpu = int(board_config.get("build.f_cpu", "16000000L").strip("UL"))
-    oscillator = board.get("hardware.oscillator", "external").lower()
-    bootloader_led = board_config.get("bootloader.led_pin", "no-led").lower()
+    oscillator = board_config.get("hardware.oscillator", "external").lower()
     bootloader_speed = board_config.get("bootloader.speed", env.subst("$UPLOAD_SPEED"))
-    bootloader_file = "urboot_%s.hex" % mcu
 
     if core == "MicroCore":
+        bootloader_file = "urboot_%s.hex" % mcu
+        bootloader_led = board_config.get("bootloader.led_pin", "no-led").lower()
         f_cpu_error = float(board_config.get("hardware.f_cpu_error", "0.0"))
-        uart = board_config.get("hardware.uart", "swio_rxb1_txb0").lower()
+        uart_pins = board_config.get("hardware.uart", "swio_rxb1_txb0").lower()
         if oscillator == "internal":
             clock_speed = f_cpu + int(f_cpu_error/100 * f_cpu)
         else:
             clock_speed = f_cpu
-    else:
-        uart = board_config.get("hardware.uart", "uart0").lower()
-        clock_speed = f_cpu
 
-    bootloader_path = join(
-        framework_dir,
-        "bootloaders",
-        "urboot",
-        "watchdog_1_s",
-        "%s_oscillator" % oscillator,
-        "%d_hz" % clock_speed,
-        "%s_baud" % bootloader_speed,
-        uart,
-        bootloader_led,
-        bootloader_file,
-    )
+        bootloader_path = join(
+            framework_dir,
+            "bootloaders",
+            "urboot",
+            "watchdog_1_s",
+            "%s_oscillator" % oscillator,
+            "%d_hz" % clock_speed,
+            "%s_baud" % bootloader_speed,
+            uart_pins,
+            bootloader_led,
+            bootloader_file,
+        )
+
+    elif core in ("MightyCore", "MegaCore", "MiniCore", "MajorCore"):
+        bootloader_file = "urboot_%s_pr_ee_ce.hex" % mcu
+        user_led = board_config.get("bootloader.led_pin", "no-led").lower()
+        if(user_led != "no-led"):
+            bootloader_led = "led+%s" % board_config.get("bootloader.led_pin", "").lower()
+        else:
+            bootloader_led = "no-led"
+        uart = board_config.get("hardware.uart", "uart0").lower()
+        if(uart == "uart0"):
+            uart_pins = board_config.get("bootloader.uart0_pins", "")
+        elif(uart == "uart1"):
+            uart_pins = board_config.get("bootloader.uart1_pins", "")
+        elif(uart == "uart2"):
+            uart_pins = board_config.get("bootloader.uart2_pins", "")
+        elif(uart == "uart3"):
+            uart_pins = board_config.get("bootloader.uart3_pins", "")
+
+        # UART2 and UART3 on the ATmega640/1280/2560 doesn't have autobaud support
+        if mcu in ("atmega640", "atmega1280", "atmega2560") and uart in ("uart2", "uart3"):
+            bootloader_path = join(
+                framework_dir,
+                "bootloaders",
+                "urboot",
+                mcu,
+                "watchdog_1_s",
+                "%s_oscillator" % oscillator,
+                "%d_hz" % f_cpu,
+                "%s_baud" % bootloader_speed,
+                uart_pins,
+                bootloader_led,
+                bootloader_file,
+            )
+        else:
+            bootloader_path = join(
+                framework_dir,
+                "bootloaders",
+                "urboot",
+                mcu,
+                "watchdog_1_s",
+                "autobaud",
+                uart_pins,
+                bootloader_led,
+                bootloader_file,
+            )
+
+    else:
+        sys.stderr.write(
+            "Error: Urboot support is not implemented for target %s and core %s\n" % mcu, core
+        )
+        env.Exit(1)
 
     return bootloader_path
 
@@ -96,12 +144,13 @@ if env.get("PIOFRAMEWORK", []):
     )
 
 bootloader_path = board.get("bootloader.file", "")
-if core in ("MiniCore", "MegaCore", "MightyCore", "MajorCore"):
+if core in ("MiniCore", "MegaCore", "MightyCore", "MajorCore", "MicroCore"):
     if not isfile(bootloader_path):
-        bootloader_path = get_suitable_optiboot_binary(framework_dir, board)
-elif core == "MicroCore":
-    if not isfile(bootloader_path):
-        bootloader_path = get_suitable_urboot_binary(framework_dir, board)
+        bootloader_type = board.get("bootloader.type", "urboot").lower()
+        if(bootloader_type == "urboot" or core == "MicroCore"):
+            bootloader_path = get_suitable_urboot_binary(framework_dir, board)
+        else:
+            bootloader_path = get_suitable_optiboot_binary(framework_dir, board)
 else:
     if not isfile(bootloader_path):
         bootloader_path = join(framework_dir, "bootloaders", bootloader_path)
@@ -118,7 +167,7 @@ print("Using bootloader image:\n%s" % bootloader_path)
 
 fuses_action = env.SConscript("fuses.py", exports="env")
 
-if core == "MicroCore":
+if bootloader_type == "urboot":
     lock_bits = board.get("bootloader.lock_bits", "0xFF")
     unlock_bits = board.get("bootloader.unlock_bits", "0xFF")
 else:

--- a/builder/bootloader.py
+++ b/builder/bootloader.py
@@ -66,7 +66,7 @@ def get_suitable_urboot_binary(framework_dir, board_config):
         f_cpu_error = float(board_config.get("hardware.f_cpu_error", "0.0"))
         uart_pins = board_config.get("hardware.uart", "swio_rxb1_txb0").lower()
         if oscillator == "internal":
-            clock_speed = f_cpu + int(f_cpu_error/100 * f_cpu)
+            clock_speed = f_cpu + int(f_cpu_error / 100 * f_cpu)
         else:
             clock_speed = f_cpu
 
@@ -91,16 +91,9 @@ def get_suitable_urboot_binary(framework_dir, board_config):
         else:
             bootloader_led = "no-led"
         uart = board_config.get("hardware.uart", "uart0").lower()
-        if(uart == "uart0"):
-            uart_pins = board_config.get("bootloader.uart0_pins", "")
-        elif(uart == "uart1"):
-            uart_pins = board_config.get("bootloader.uart1_pins", "")
-        elif(uart == "uart2"):
-            uart_pins = board_config.get("bootloader.uart2_pins", "")
-        elif(uart == "uart3"):
-            uart_pins = board_config.get("bootloader.uart3_pins", "")
+        uart_pins = board_config.get("bootloader.%s_pins" % uart, "")
 
-        # UART2 and UART3 on the ATmega640/1280/2560 doesn't have autobaud support
+        # UART2 and UART3 on the ATmega640/1280/2560 don't have autobaud support
         if mcu in ("atmega640", "atmega1280", "atmega2560") and uart in ("uart2", "uart3"):
             bootloader_path = join(
                 framework_dir,
@@ -130,7 +123,8 @@ def get_suitable_urboot_binary(framework_dir, board_config):
 
     else:
         sys.stderr.write(
-            "Error: Urboot support is not implemented for target %s and core %s\n" % mcu, core
+            "Error: Urboot support is not implemented for target %s and core %s\n"
+            % (mcu, core)
         )
         env.Exit(1)
 
@@ -144,10 +138,11 @@ if env.get("PIOFRAMEWORK", []):
     )
 
 bootloader_path = board.get("bootloader.file", "")
+bootloader_type = None
 if core in ("MiniCore", "MegaCore", "MightyCore", "MajorCore", "MicroCore"):
     if not isfile(bootloader_path):
         bootloader_type = board.get("bootloader.type", "urboot").lower()
-        if(bootloader_type == "urboot" or core == "MicroCore"):
+        if bootloader_type == "urboot" or core == "MicroCore":
             bootloader_path = get_suitable_urboot_binary(framework_dir, board)
         else:
             bootloader_path = get_suitable_optiboot_binary(framework_dir, board)
@@ -168,8 +163,8 @@ print("Using bootloader image:\n%s" % bootloader_path)
 fuses_action = env.SConscript("fuses.py", exports="env")
 
 if bootloader_type in ("no_bootloader", "urboot"):
-    lock_bits = board.get("bootloader.lock_bits", "0xff")
-    unlock_bits = board.get("bootloader.unlock_bits", "0xff")
+    lock_bits = board.get("bootloader.lock_bits", "0xFF")
+    unlock_bits = board.get("bootloader.unlock_bits", "0xFF")
 else:
     lock_bits = board.get("bootloader.lock_bits", "0x0F")
     unlock_bits = board.get("bootloader.unlock_bits", "0x3F")

--- a/builder/bootloader.py
+++ b/builder/bootloader.py
@@ -167,9 +167,9 @@ print("Using bootloader image:\n%s" % bootloader_path)
 
 fuses_action = env.SConscript("fuses.py", exports="env")
 
-if bootloader_type == "urboot":
-    lock_bits = board.get("bootloader.lock_bits", "0xFF")
-    unlock_bits = board.get("bootloader.unlock_bits", "0xFF")
+if bootloader_type in ("no_bootloader", "urboot"):
+    lock_bits = board.get("bootloader.lock_bits", "0xff")
+    unlock_bits = board.get("bootloader.unlock_bits", "0xff")
 else:
     lock_bits = board.get("bootloader.lock_bits", "0x0F")
     unlock_bits = board.get("bootloader.unlock_bits", "0x3F")

--- a/builder/frameworks/arduino.py
+++ b/builder/frameworks/arduino.py
@@ -58,13 +58,6 @@ def get_bootloader_size():
             return 1024
         elif max_size > 4096 and max_size <= 32768:
             return 512
-    elif upload_protocol == "avr109":
-        return 4096
-    elif upload_protocol == "wiring":
-        if max_size > 131072:
-            return 8192
-        else:
-            return 4096
     return 0
 
 

--- a/builder/frameworks/arduino.py
+++ b/builder/frameworks/arduino.py
@@ -45,10 +45,21 @@ assert isdir(FRAMEWORK_DIR)
 
 def get_bootloader_size():
     max_size = board.get("upload.maximum_size")
-    if max_size > 4096 and max_size <= 32768:
-        return 512
-    elif max_size >= 65536 or board.get("build.mcu").startswith("at90can32"):
-        return 1024
+    if (
+        build_core in ("MightyCore", "MegaCore", "MiniCore", "MajorCore", "MicroCore") and \
+        board.get("bootloader.type", "urboot").lower() == "urboot"
+    ):
+        if max_size >= 65536 or board.get("build.mcu").startswith("at90can32"):
+            return 512
+        elif max_size >= 4096:
+            return 384
+        else:
+            return 256
+    else:
+        if max_size >= 65536 or board.get("build.mcu").startswith("at90can32"):
+            return 1024
+        elif max_size > 4096 and max_size <= 32768:
+            return 512
     return 0
 
 

--- a/builder/frameworks/arduino.py
+++ b/builder/frameworks/arduino.py
@@ -44,22 +44,27 @@ assert isdir(FRAMEWORK_DIR)
 
 
 def get_bootloader_size():
+    upload_protocol = env.subst("$UPLOAD_PROTOCOL")
     max_size = board.get("upload.maximum_size")
-    if (
-        build_core in ("MightyCore", "MegaCore", "MiniCore", "MajorCore", "MicroCore") and \
-        board.get("bootloader.type", "urboot").lower() == "urboot"
-    ):
+    if upload_protocol == "urclock":
         if max_size >= 65536 or board.get("build.mcu").startswith("at90can32"):
             return 512
         elif max_size >= 4096:
             return 384
         else:
             return 256
-    else:
+    elif upload_protocol == "arduino":
         if max_size >= 65536 or board.get("build.mcu").startswith("at90can32"):
             return 1024
         elif max_size > 4096 and max_size <= 32768:
             return 512
+    elif upload_protocol == "avr109":
+        return 4096
+    elif upload_protocol == "wiring":
+        if max_size > 131072:
+            return 8192
+        else:
+            return 4096
     return 0
 
 
@@ -145,10 +150,7 @@ else:
 # Take into account bootloader size
 #
 
-if (
-    build_core in ("MiniCore", "MegaCore", "MightyCore", "MajorCore")
-    and board.get("hardware.uart", "uart0") != "no_bootloader"
-):
+if build_core in ("MiniCore", "MegaCore", "MightyCore", "MajorCore", "MicroCore"):
     upload_section = board.get("upload")
     upload_section["maximum_size"] -= board.get(
         "bootloader.size", get_bootloader_size()

--- a/builder/fuses.py
+++ b/builder/fuses.py
@@ -545,7 +545,7 @@ if core in ("MiniCore", "MegaCore", "MightyCore", "MajorCore", "MicroCore"):
 
     lfuse = lfuse or hex(get_lfuse(target, f_cpu, oscillator, bod, eesave, ckout))
     hfuse = hfuse or hex(get_hfuse(target, uart, oscillator, bod, eesave, jtagen, bootloader_type))
-    efuse = efuse or hex(get_efuse(target, uart, bod, cfd, bootloader_type))
+    efuse = efuse or get_efuse(target, uart, bod, cfd, bootloader_type)
     lock = lock or hex(get_lock_bits(target, uart, bootloader_type))
 
 env.Replace(

--- a/builder/main.py
+++ b/builder/main.py
@@ -216,6 +216,9 @@ else:
         UPLOADEEPCMD="$UPLOADER $UPLOADERFLAGS -U eeprom:w:$SOURCES:i",
     )
 
+    if(upload_protocol == "urclock"):
+        env.Append(UPLOADERFLAGS=["-xnometadata"])
+
     if int(ARGUMENTS.get("PIOVERBOSE", 0)):
         env.Prepend(UPLOADERFLAGS=["-v"])
 

--- a/builder/main.py
+++ b/builder/main.py
@@ -216,7 +216,7 @@ else:
         UPLOADEEPCMD="$UPLOADER $UPLOADERFLAGS -U eeprom:w:$SOURCES:i",
     )
 
-    if(upload_protocol == "urclock"):
+    if upload_protocol == "urclock":
         env.Append(UPLOADERFLAGS=["-xnometadata"])
 
     if int(ARGUMENTS.get("PIOVERBOSE", 0)):


### PR DESCRIPTION
See #320 for details.

This PR adds support for the Urboot bootloader and makes it the default choice when using MigntyCore, MiniCore, MegaCore, or MajorCore. If you don't know what Urboot is, please take a look at the [README in the Urboot repo](https://github.com/stefanrueger/urboot).

Optiboot is still available, but not the default option anymore. You can still force Optiboot by utilizing   
`board_bootloader.type = [urboot, optiboot, no_bootloader]`

All these changes will be documented in the PlatformIO.md document in each of the core repos, so users have a ready-made platformio.ini template they can use to get started.

I had to make quite a lot of changes to the build files to get it working. Urboot hex files have different names than the Optiboot flash files, and Urboot is a "vector bootloader", which means that there's no need for a hardware bootloader section. It also has support for EEPROM uploads (not the ATtiny13, but _all_ other target running Urboot).

On chips with 64kB flash or more, the bootloader size has been reduced from 1024 bytes to 512 bytes. On chips with 32kB flash or less, the bootload size has been reduced from 512 bytes to 384 bytes. The bootloader size on the ATtiny13/A is only 256 bytes, and that's why it doesn't have EEPROM support. Note that all bootloaders<b>*</b> support autobaud, which lets the user set whatever baud rate he/she likes without having to re-flash the bootloader.

@valeros and/or @ivankravets please review! I'm more than open to suggestions on how the code could be further improved. As you can probably see, I'm no Python programmer, so pardon my "C accent" 😄

The Urboot bootloader requires Avrdude 7.1 or greater, and my cores are already using Avrdude 7.2, so this shouldn't be a problem.

<b>*</b> The ATtiny13 does not support auto baud due to the limited flash capacity. UART2 and UART3 on the ATmega640/1280/2560 do not support autobaud either, since their registers are placed further up in the io memory (addresses greater than 0xff), requiring extra instructions to read and write to these. PlatformIO will load a "fixed" bootloader in this case, where the clock frequency (f_cpu) and bootloader baud rate have to be known, just like with Optiboot.