### PR TITLE
Adding ArduinoRS485-ArduinoModbus library support for Controllino MAXI and MEGA

### DIFF
--- a/boards/controllino_maxi.json
+++ b/boards/controllino_maxi.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "core": "arduino",
-    "extra_flags": "-DARDUINO_AVR_MEGA2560",
+    "extra_flags": "-DARDUINO_AVR_MEGA2560 -DRS485_SERIAL_PORT=Serial3 -DRS485_DEFAULT_TX_PIN=14 -DCUSTOM_RS485_DEFAULT_DE_PIN=75 -DCUSTOM_RS485_DEFAULT_RE_PIN=76",
     "f_cpu": "16000000L",
     "hwids": [
       [

--- a/boards/controllino_mega.json
+++ b/boards/controllino_mega.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "core": "arduino",
-    "extra_flags": "-DARDUINO_AVR_MEGA2560",
+    "extra_flags": "-DARDUINO_AVR_MEGA2560 -DRS485_SERIAL_PORT=Serial3 -DRS485_DEFAULT_TX_PIN=14 -DCUSTOM_RS485_DEFAULT_DE_PIN=75 -DCUSTOM_RS485_DEFAULT_RE_PIN=76",
     "f_cpu": "16000000L",
     "hwids": [
       [


### PR DESCRIPTION
We recently added this definitions for our BSP for ArduinoIDE, like our products are oriented to automation industry, ArduinoRS485 and ArduinoModbus library support is important for our clients.

Will be better to be add these defines within pins_arduino.h, but the repo https://github.com/platformio/platformio-pkg-framework-arduinoavr is archieved, so this PR could be a solution.