### PR TITLE
Added attiny84_cw_pinmap board option

### DIFF
--- a/boards/attiny84_cw_pinmap
+++ b/boards/attiny84_cw_pinmap
@@ -1,0 +1,24 @@
+{
+  "build": {
+    "core": "tiny",
+    "extra_flags": "-DARDUINO_AVR_ATTINYX4",
+    "f_cpu": "8000000L",
+    "mcu": "attiny84",
+    "variant": "tinyX4_reverse"
+  },
+  "debug": {
+    "simavr_target": "attiny84"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "Generic ATtiny84",
+  "upload": {
+    "extra_flags": "-e",
+    "maximum_ram_size": 512,
+    "maximum_size": 8192,
+    "protocol": "usbtiny"
+  },
+  "url": "http://www.atmel.com/devices/ATTINY84.aspx",
+  "vendor": "Atmel"
+}


### PR DESCRIPTION
Created a board for ATtiny84 using the reverse (clockwise) pin mappinig, as opposed to the default CCW pinmapping. Reads from the "tinyX4_reverse" board variant.

Why? Tldr: the mapping has changed over time, and newer projects generally use CW mapping. It's odd that pio defaults to CCW. Adding this to the list would at least make it easily (and EXPLICITLY, no ambiguity) selectable, without breaking pre-existing projects by modifying the original "attiny84" board.

See https://github.com/SpenceKonde/ATTinyCore/blob/v2.0.0-devThis-is-the-head-submit-PRs-against-this/avr/extras/ATtiny_x4.md for details on why this pinmapping exists. 

Found it exhausting to manually add the variant every time despite it pre-existing in the boards list.