### PR TITLE
Update toolchain-atmelavr version

### DIFF
--- a/platform.json
+++ b/platform.json
@@ -29,7 +29,7 @@
     "toolchain-atmelavr": {
       "type": "toolchain",
       "owner": "platformio",
-      "version": "~1.70300.0"
+      "version": "~3.70300.220127"
     },
     "framework-arduino-avr": {
       "type": "framework",


### PR DESCRIPTION
There's been a newer version of toolchain-atmelavr for 3 years now. Why not use it?

Note: I have tested nothing. I only updated the version number in the platform.json.

Has a pretty good chance of fixing #313, #292, #275, and maybe others.