### PR TITLE
Support a variant-only framework

### DIFF
--- a/builder/frameworks/arduino.py
+++ b/builder/frameworks/arduino.py
@@ -22,7 +22,7 @@ kinds of creative coding, interactive objects, spaces or physical experiences.
 http://arduino.cc/en/Reference/HomePage
 """
 
-from os.path import isdir, join
+from os.path import isdir, join, isabs
 
 from SCons.Script import DefaultEnvironment
 
@@ -41,6 +41,21 @@ elif build_core != "arduino":
         "framework-arduino-avr-%s" % build_core.lower())
 
 assert isdir(FRAMEWORK_DIR)
+
+
+def get_variants_dir():
+    if "build.variants_dir" not in board and "build.variant_pkg" not in board:
+        return join(FRAMEWORK_DIR, "variants")
+    if "build.variants_dir" in board:
+        if isabs(env.subst(board.get("build.variants_dir"))):
+            return board.get("build.variants_dir", "")
+        return join("$PROJECT_DIR", board.get("build.variants_dir"))
+
+    elif board.get("build.variant_pkg", ""):
+        full_variant_pkg = (
+            "framework-arduino-avr-%s" % board.get("build.variant_pkg").lower()
+        )
+        return join(platform.get_package_dir(full_variant_pkg), "variants")
 
 
 def get_bootloader_size():
@@ -168,9 +183,7 @@ elif build_core in ("tiny", "tinymodern"):
 libs = []
 
 if "build.variant" in board:
-    variants_dir = join(
-        "$PROJECT_DIR", board.get("build.variants_dir")) if board.get(
-            "build.variants_dir", "") else join(FRAMEWORK_DIR, "variants")
+    variants_dir = get_variants_dir()
 
     env.Append(
         CPPPATH=[

--- a/platform.py
+++ b/platform.py
@@ -20,10 +20,11 @@ class AtmelavrPlatform(PlatformBase):
     def configure_default_packages(self, variables, targets):
         if not variables.get("board"):
             return super().configure_default_packages(variables, targets)
+        board = self.board_config(variables.get("board"))
 
         build_core = variables.get(
-            "board_build.core", self.board_config(variables.get("board")).get(
-                "build.core", "arduino"))
+            "board_build.core", board.get("build.core", "arduino")
+        )
 
         if "arduino" in variables.get(
                 "pioframework", []) and build_core != "arduino":
@@ -47,10 +48,17 @@ class AtmelavrPlatform(PlatformBase):
             self.packages[framework_package]["optional"] = False
             self.packages["framework-arduino-avr"]["optional"] = True
 
+        variant_package = (
+            "framework-arduino-avr-%s" % (board.get("build.variant_pkg", ""),)
+            if board.get("build.variant_pkg", "")
+            else None
+        )
+        if variant_package and variant_package in self.packages:
+            self.packages[variant_package]["optional"] = False
+
         upload_protocol = variables.get(
-            "upload_protocol",
-            self.board_config(variables.get("board")).get(
-                "upload.protocol", ""))
+            "upload_protocol", board.get("upload.protocol", "")
+        )
         disabled_tool = "tool-micronucleus"
         required_tool = ""
 


### PR DESCRIPTION
This supports a 'variant_pkg' which allows users to create a variant-only package - ie, one that has no core libraries, just the pin definition files.
This is the AVR match to https://github.com/platformio/platform-atmelsam/pull/248.